### PR TITLE
Increase max_attempts value in deploy.sh

### DIFF
--- a/Chapter 3 Files/deploy.sh
+++ b/Chapter 3 Files/deploy.sh
@@ -104,7 +104,7 @@ function setpasswords() {
   fi
 
   echo -e "\e[32m[X]\e[0m Waiting for Elasticsearch to be ready"
-  max_attempts=60
+  max_attempts=180
   attempt=0
   while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' --cacert certs/root-ca.crt --user elastic:${temp} https://127.0.0.1:9200)" != "200" ]]; do
     printf '.'


### PR DESCRIPTION
## 💭 Motivation and context ##

Original value was set to max_attempts=60, when running a new install deploy.sh would exit early 

When running a new install, deploy.sh would exit early because the while loop's condition would be met. max_attempts=60 is too low so bumping it up to 180 to accommodate slower hardware. 

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Set max_attempts=180 and ran `./deploy.sh install`. 

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).