### PR TITLE
Bugfix - Generate Kibana/Elasticsearch credentials with existing elastic password

### DIFF
--- a/Chapter 3 Files/dashboard_update.sh
+++ b/Chapter 3 Files/dashboard_update.sh
@@ -8,7 +8,7 @@ if [ -r /opt/lme/lme.conf ]; then
   #reference this file as a source
   . /opt/lme/lme.conf
   #check if the version number is equal to the one we want
-  if [ "$version" == "1.0" ]; then
+  if [ "$version" == "1.2.0" ]; then
     echo -e "\e[32m[X]\e[0m Updating from git repo"
     git -C /opt/lme/ pull
     #make sure the hostname variable is present

--- a/Chapter 3 Files/deploy.sh
+++ b/Chapter 3 Files/deploy.sh
@@ -3,6 +3,10 @@
 # LME Deploy Script        #
 ############################
 # This script configures a host for LME including generating certificates and populating configuration files.
+
+# Put the latest version number here
+version='1.2.0'
+
 DATE="$(date '+%Y-%m-%d-%H:%M:%S')"
 
 #prompt for y/n
@@ -610,7 +614,7 @@ function configelasticsearch() {
 function writeconfig() {
   echo -e "\n\e[32m[X]\e[0m Writing LME Config"
   #write LME version
-  echo "version=1.0" >/opt/lme/lme.conf
+  echo "version=$version" >/opt/lme/lme.conf
   if [ -z "$logstashcn" ]; then
     # $logstashcn is not set - so this function is not called from an initial install
     read -e -p "Enter the Fully Qualified Domain Name (FQDN) of this Linux server: " logstashcn
@@ -877,7 +881,7 @@ function upgrade() {
   crontab -l | sed -E '/lme_update.sh|dashboard_update.sh/d' | crontab -
 
   #grab latest version
-  latest="1.2.0"
+  latest=$version
 
   #check if the config file we're now creating on new installs exists
   if [ -r /opt/lme/lme.conf ]; then
@@ -956,6 +960,8 @@ function upgrade() {
       sudo docker stack rm lme
       pulllme
       sudo docker stack deploy lme --compose-file /opt/lme/Chapter\ 3\ Files/docker-compose-stack-live.yml
+      sudo cp -rapf /opt/lme/lme.conf /opt/lme/lme.conf.bku
+      sudo sed -i "s/version=1.0/version=$latest/g" /opt/lme/lme.conf
     elif [ "$version" == $latest ]; then
       echo -e "\e[32m[X]\e[0m You're on the latest version!"
     else

--- a/Chapter 3 Files/deploy.sh
+++ b/Chapter 3 Files/deploy.sh
@@ -979,6 +979,11 @@ function upgrade() {
       echo -e "\e[32m[X]\e[0m Copying lme.conf -> lme.conf.bku"
       sudo cp -rapf /opt/lme/lme.conf /opt/lme/lme.conf.bku
       sudo sed -i "s/version=1.0/version=$latest/g" /opt/lme/lme.conf
+
+      echo -e "\e[32m[X]\e[0m Copying dashboard_update.sh -> dashboard_update.sh.bku"
+      sudo cp -rapf /opt/lme/dashboard_update.sh /opt/lme/dashboard_update.sh.bku
+      sudo sed -i "s/\"\$version\" == \"1.0\"/\"\$version\" == \"$latest\"/g" /opt/lme/dashboard_update.sh
+
       echo -e "\e[32m[X]\e[0m You're on the latest version: $latest!"
     elif [ "$version" == $latest ]; then
       echo -e "\e[32m[X]\e[0m You're on the latest version!"

--- a/Chapter 3 Files/deploy.sh
+++ b/Chapter 3 Files/deploy.sh
@@ -941,6 +941,7 @@ function upgrade() {
       echo -e "\e[32m[X]\e[0m Recreating Docker stack"
       docker config create logstash.conf /opt/lme/Chapter\ 3\ Files/logstash.edited.conf
       docker config create logstash_custom.conf /opt/lme/Chapter\ 3\ Files/logstash_custom.conf
+      pulllme
       deploylme
       if [ -z "$logstashcn" ]; then
         read -e -p "Enter the Fully Qualified Domain Name (FQDN) of this Linux server: " logstashcn
@@ -1004,6 +1005,7 @@ function renew() {
 
   populatecerts
   echo -e "\e[32m[X]\e[0m Recreating Docker stack"
+  pulllme
   deploylme
 }
 

--- a/Chapter 3 Files/deploy.sh
+++ b/Chapter 3 Files/deploy.sh
@@ -877,7 +877,7 @@ function upgrade() {
   crontab -l | sed -E '/lme_update.sh|dashboard_update.sh/d' | crontab -
 
   #grab latest version
-  latest="1.0"
+  latest="1.2.0"
 
   #check if the config file we're now creating on new installs exists
   if [ -r /opt/lme/lme.conf ]; then
@@ -949,6 +949,12 @@ function upgrade() {
       zipfiles
       fixreadability
 
+    elif [ "$version" == "1.0" ]; then
+      sudo mkdir -p /opt/lme/Chapter\ 3\ Files/backup_config
+      sudo cp /opt/lme/Chapter\ 3\ Files/docker-compose-stack-live.yml /opt/lme/Chapter\ 3\ Files/backup_config/docker-compose-stack-live.yml
+      sudo sed -i 's/8.7.1/8.11.1/g' /opt/lme/Chapter\ 3\ Files/docker-compose-stack-live.yml
+      sudo docker stack rm lme
+      sudo docker stack deploy lme --compose-file /opt/lme/Chapter\ 3\ Files/docker-compose-stack-live.yml
     elif [ "$version" == $latest ]; then
       echo -e "\e[32m[X]\e[0m You're on the latest version!"
     else

--- a/Chapter 3 Files/deploy.sh
+++ b/Chapter 3 Files/deploy.sh
@@ -739,6 +739,8 @@ function install() {
       prompt "confirm password \"$OLD_ELASTIC_PASS\""
       res=$?
     done
+  else
+    generatepasswords
   fi
 
   if [ "$selfsignedyn" == "y" ]; then
@@ -802,7 +804,6 @@ function install() {
 
   initdockerswarm
   populatecerts
-  generatepasswords
   populatelogstashconfig
   configuredocker
   pulllme
@@ -835,7 +836,9 @@ function install() {
 
   #fix readability:
   fixreadability
+}
 
+function displaycredentials() {
   echo ""
   echo "##################################################################################"
   echo "## Kibana/Elasticsearch Credentials are (these will not be accessible again!)"

--- a/Chapter 3 Files/deploy.sh
+++ b/Chapter 3 Files/deploy.sh
@@ -954,6 +954,7 @@ function upgrade() {
       sudo cp /opt/lme/Chapter\ 3\ Files/docker-compose-stack-live.yml /opt/lme/Chapter\ 3\ Files/backup_config/docker-compose-stack-live.yml
       sudo sed -i 's/8.7.1/8.11.1/g' /opt/lme/Chapter\ 3\ Files/docker-compose-stack-live.yml
       sudo docker stack rm lme
+      pulllme
       sudo docker stack deploy lme --compose-file /opt/lme/Chapter\ 3\ Files/docker-compose-stack-live.yml
     elif [ "$version" == $latest ]; then
       echo -e "\e[32m[X]\e[0m You're on the latest version!"

--- a/Chapter 3 Files/deploy.sh
+++ b/Chapter 3 Files/deploy.sh
@@ -838,6 +838,11 @@ function install() {
 
   #fix readability:
   fixreadability
+  
+  #if old es password is empty, then user is not overriding existing credentials
+  if [ -z "$OLD_ELASTIC_PASS" ]; then
+    displaycredentials
+  fi
 }
 
 function displaycredentials() {

--- a/Chapter 3 Files/deploy.sh
+++ b/Chapter 3 Files/deploy.sh
@@ -104,9 +104,11 @@ function setroles() {
 
 function setpasswords() {
   temp="temp"
-  #override temp password if overwriting an old docker container
+  # override temp and elastic user password if user has an existing LME install 
+  # elastic user password is used to create kibana, logstash/writer, dashboard update user credentials and to set roles correctly
   if [ -v OLD_ELASTIC_PASS ]; then
     temp=$OLD_ELASTIC_PASS
+    $elastic_user_pass=$OLD_ELASTIC_PASS
   fi
 
   echo -e "\e[32m[X]\e[0m Waiting for Elasticsearch to be ready"

--- a/Chapter 3 Files/deploy.sh
+++ b/Chapter 3 Files/deploy.sh
@@ -108,7 +108,7 @@ function setpasswords() {
   # elastic user password is used to create kibana, logstash/writer, dashboard update user credentials and to set roles correctly
   if [ -v OLD_ELASTIC_PASS ]; then
     temp=$OLD_ELASTIC_PASS
-    $elastic_user_pass=$OLD_ELASTIC_PASS
+    elastic_user_pass=$OLD_ELASTIC_PASS
   fi
 
   echo -e "\e[32m[X]\e[0m Waiting for Elasticsearch to be ready"
@@ -741,8 +741,6 @@ function install() {
       prompt "confirm password \"$OLD_ELASTIC_PASS\""
       res=$?
     done
-  else
-    generatepasswords
   fi
 
   if [ "$selfsignedyn" == "y" ]; then
@@ -806,6 +804,7 @@ function install() {
 
   initdockerswarm
   populatecerts
+  generatepasswords
   populatelogstashconfig
   configuredocker
   pulllme
@@ -839,10 +838,7 @@ function install() {
   #fix readability:
   fixreadability
   
-  #if old es password is empty, then user is not overriding existing credentials
-  if [ -z "$OLD_ELASTIC_PASS" ]; then
-    displaycredentials
-  fi
+  displaycredentials
 }
 
 function displaycredentials() {

--- a/Chapter 3 Files/docker-compose-stack.yml
+++ b/Chapter 3 Files/docker-compose-stack.yml
@@ -5,7 +5,7 @@ version: '3.9'
 services:
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.7.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.1
     environment:
       - node.name=es01
       # - discovery.seed_hosts=es01
@@ -65,7 +65,7 @@ services:
     # depends_on:
     # elasticsearch:
     #   condition: service_healthy
-    image: docker.elastic.co/kibana/kibana:8.7.1
+    image: docker.elastic.co/kibana/kibana:8.11.1
     environment:
       SERVER_NAME: kibana
       ELASTICSEARCH_HOSTS: https://elasticsearch:9200
@@ -101,7 +101,7 @@ services:
       retries: 120
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:8.7.1
+    image: docker.elastic.co/logstash/logstash:8.11.1
     environment:
       XPACK_MONITORING_ENABLED: "false"
       PIPELINE_ECS_COMPATIBILITY: v8


### PR DESCRIPTION
## 🗣 Description ##

The `./deploy.sh install` script will prompt the user if they have an old elastic user password from a previous LME installation. This feature allows the user to use the same password if required to do a reinstallation of LME. 

This elastic password will be used to generate:
- kibana system password
- logstash system/writer passwords
- dashboard update user password

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The script was generating a new password even if the user entered their old elastic user password. When logging into the Kibana for the first time neither the new or old passwords would authenticate properly.

This PR resolves #81 

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Run `./deploy.sh uninstall`, then `./deploy.sh install` from Linux server. When prompted to enter an old elastic user password, enter the previous password you've used. Continue with Chapter 3 installation (cp files_for_windows over to DC1, cp its contents into lme dir, stop winlogbeat service and restart, install certs), then access Kibana frontend. The old username/password should authenticate. 

Repeat above steps but don't enter an old elastic password. This should generate a new elastic user password.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.

