### PR TITLE
Update workflow file to include linting and static security scans

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,6 @@ on:
     push:
       branches:
         - main
-        - update-workflows-1
       tags:
         - 'v[0-9]+.[0-9]+.[0-9]+*'  # match basic semver tags
     pull_request:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,32 +1,72 @@
----
 on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'  # match basic semver tags
-  pull_request:
-    branches:
-      - main
-
+    workflow_dispatch:
+    push:
+      branches:
+        - main
+        - update-workflows-1
+      tags:
+        - 'v[0-9]+.[0-9]+.[0-9]+*'  # match basic semver tags
+    pull_request:
+      branches:
+         - main
+         - 'release-*'
+  
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Linters
-        run: true  # place-holder
+      - name: Checkout
+        uses: actions/checkout@v4
 
-  test:
+      - name: Lint Shell Scripts
+        continue-on-error: true
+        run: |
+          sudo apt-get update
+          sudo apt-get install shellcheck
+          shellcheck **/*.sh
+  
+      - name: Lint PowerShell Scripts
+        continue-on-error: true
+        run: |
+          pwsh -Command "Invoke-ScriptAnalyzer -EnableExit -Recurse -Path ."
+  
+      - name: Lint Lua
+        continue-on-error: true
+        run: |
+          sudo apt-get install -y luarocks
+          sudo luarocks install luacheck
+          luacheck **/*.lua
+  
+      - name: Lint TeX Files
+        continue-on-error: true
+        run: |
+          sudo apt-get install chktex
+          chktex **/*.tex
+
+      - name: Lint YAML Files
+        continue-on-error: true
+        run: |
+          sudo apt-get update
+          sudo apt-get install yamllint
+          yamllint -f parsable **/*.yml
+          
+  semgrep-scan:
     runs-on: ubuntu-latest
+    container: 
+      image: returntocorp/semgrep:latest
     steps:
-      - name: Tests
-        run: true  # place-holder
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Semgrep Scan
+        continue-on-error: true
+        run: |
+          semgrep --config "p/r2c" .
 
   release:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [lint, test]
+    needs: [lint, semgrep-scan]
     steps:
       - name: Checkout
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0


### PR DESCRIPTION
## 🗣 Description ##

I have updated the main.yml to include linting of our code as well as a semgrep static security scan. 

As of now the actions are set to run during the following events: 

1. A push of any code to main
2. A PR to main or to any branch that starts with 'release-*'

As of now I have set the scans to allow failure. This means they do in fact have findings - but in order to not jam up the pipeline they will just continue. Results should be reviewed and improvements made to ymls, install scripts etc as we see fit. Additionally, I should be able to add ignores for items we think are false positives or not needed. 

Here's an example of a pipeline run: 

lint job: https://github.com/cisagov/LME/actions/runs/7209632958/job/19640983024
semgrep job: https://github.com/cisagov/LME/actions/runs/7209632958/job/19640982724

You should also be able to see the results of the checks in this PR at the bottom near review required.

The release job will be skipped unless we are actually creating a release with a 'tag'
