### PR TITLE
Remove elastic user password prompt from deploy.sh

### DIFF
--- a/Chapter 3 Files/deploy.sh
+++ b/Chapter 3 Files/deploy.sh
@@ -103,11 +103,7 @@ function setroles() {
 }
 
 function setpasswords() {
-  temp="temp"
-  #override temp password if overwriting an old docker container
-  if [ -v OLD_ELASTIC_PASS ]; then
-    temp=$OLD_ELASTIC_PASS
-  fi
+  temp="temp" 
 
   echo -e "\e[32m[X]\e[0m Waiting for Elasticsearch to be ready"
   max_attempts=25
@@ -729,17 +725,7 @@ function install() {
   echo -e "\e[32m[X]\e[0m Configuring winlogbeat config and certificates to use $logstaship as the IP and $logstashcn as the DNS"
 
   read -e -p "This script will use self signed certificates for communication and encryption. Do you want to continue with self signed certificates? ([y]es/[n]o): " -i "y" selfsignedyn
-  read -e -p "Skip Docker Install? ([y]es/[n]o): " -i "n" skipdinstall
-  read -e -p "Do you have an old elastic user password from a previous LME install? ([y]es/[n]o): " -i "n" old_elastic_user_pass
-
-  if [ "$old_elastic_user_pass" == "y" ]; then
-    res= false
-    while [ ! $res ]; do
-      read -e -p "PASSWORD: " OLD_ELASTIC_PASS
-      prompt "confirm password \"$OLD_ELASTIC_PASS\""
-      res=$?
-    done
-  fi
+  read -e -p "Skip Docker Install? ([y]es/[n]o): " -i "n" skipdinstall 
 
   if [ "$selfsignedyn" == "y" ]; then
     #make certs

--- a/Chapter 3 Files/deploy.sh
+++ b/Chapter 3 Files/deploy.sh
@@ -117,7 +117,7 @@ function setpasswords() {
       exit 1
     fi
   done
-  echo "Elasticsearch is up and running."
+  echo -e "\n\e[32m[X]\e[0m Elasticsearch is up and running."
 
   echo -e "\e[32m[X]\e[0m Setting elastic user password"
   curl --cacert certs/root-ca.crt --user elastic:${temp} -X POST "https://127.0.0.1:9200/_security/user/elastic/_password" -H 'Content-Type: application/json' -d' { "password" : "'"$elastic_user_pass"'"} '
@@ -822,6 +822,13 @@ function install() {
   #fix readability:
   fixreadability
 
+  displaycredentials
+
+  echo -e "If you prefer to set your own elastic user password, then refer to our troubleshooting documentation:"
+  echo -e "https://github.com/cisagov/LME/blob/main/docs/markdown/reference/troubleshooting.md#containers-restartingnot-running\n\n" 
+}
+
+function displaycredentials() {
   echo ""
   echo "##################################################################################"
   echo "## Kibana/Elasticsearch Credentials are (these will not be accessible again!)"

--- a/Chapter 3 Files/deploy.sh
+++ b/Chapter 3 Files/deploy.sh
@@ -825,7 +825,7 @@ function install() {
   displaycredentials
 
   echo -e "If you prefer to set your own elastic user password, then refer to our troubleshooting documentation:"
-  echo -e "https://github.com/cisagov/LME/blob/main/docs/markdown/reference/troubleshooting.md#containers-restartingnot-running\n\n" 
+  echo -e "https://github.com/cisagov/LME/blob/main/docs/markdown/reference/troubleshooting.md#changing-elastic-username-password\n\n" 
 }
 
 function displaycredentials() {


### PR DESCRIPTION
## 🗣 Description ##

- Remove the prompt asking the user if they have an elastic user password
- Move credentials that are displayed at the end of the script into a function, link troubleshooting.md docs

Resolves #81 

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The `./deploy.sh install` script prompted the user if they have an old elastic user password from a previous LME installation. This feature allows the user to use the same password if required to do a reinstallation of LME. However, the reasoning for this step is redundant since the user can change their elastic password at any time without using the install script. 

When logging into Kibana for the first time neither the new or old passwords would authenticate properly. This PR removes the feature in order to resolve this issue. 

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Run `./deploy.sh uninstall`, then `./deploy.sh install` from the Linux server. 

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Rebase local branch to latest updates from release-1.3.0
- [x] Update troubleshooting.md documentation to demonstrate how elasticsearch API can be used to change password with a curl request


