### PR TITLE
Update troubleshooting.md

### DIFF
--- a/docs/markdown/reference/troubleshooting.md
+++ b/docs/markdown/reference/troubleshooting.md
@@ -315,6 +315,8 @@ sudo docker stack deploy lme --compose-file /opt/lme/Chapter\ 3\ Files/docker-co
 
 After doing an install if you wish to change the password to the elastic username you can use the following command: 
 
+NOTE: You will need to run this command with an account that can access /opt/lme. 
+
 ```
 curl -X POST "https://127.0.0.1:9200/_security/user/elastic/_password" -H "Content-Type: application/json" -d'
 {
@@ -322,4 +324,4 @@ curl -X POST "https://127.0.0.1:9200/_security/user/elastic/_password" -H "Conte
 }' --cacert /opt/lme/Chapter\ 3\ Files/certs/root-ca.crt -u elastic:currentpassword
 ```
 
-Replace 'currentpassword' with your current password and 'newpassword' with the password you would like to change it to.
+Replace 'currentpassword' with your current password and 'newpassword' with the password you would like to change it to. 

--- a/docs/markdown/reference/troubleshooting.md
+++ b/docs/markdown/reference/troubleshooting.md
@@ -315,7 +315,7 @@ sudo docker stack deploy lme --compose-file /opt/lme/Chapter\ 3\ Files/docker-co
 
 After doing an install if you wish to change the password to the elastic username you can use the following command: 
 
-NOTE: You will need to run this command with an account that can access /opt/lme if you can't sudo the user account will at least need to be able to access the certs located in the command. 
+NOTE: You will need to run this command with an account that can access /opt/lme. If you can't sudo the user account will at least need to be able to access the certs located in the command. 
 
 ```
 sudo curl -X POST "https://127.0.0.1:9200/_security/user/elastic/_password" -H "Content-Type: application/json" -d'

--- a/docs/markdown/reference/troubleshooting.md
+++ b/docs/markdown/reference/troubleshooting.md
@@ -325,3 +325,5 @@ curl -X POST "https://127.0.0.1:9200/_security/user/elastic/_password" -H "Conte
 ```
 
 Replace 'currentpassword' with your current password and 'newpassword' with the password you would like to change it to. 
+
+Utilize environment variables in place of currentpassword and newpassword to avoid saving your password to console history. If not we recommend you clear your history after changing the password with ```history -c```

--- a/docs/markdown/reference/troubleshooting.md
+++ b/docs/markdown/reference/troubleshooting.md
@@ -315,10 +315,10 @@ sudo docker stack deploy lme --compose-file /opt/lme/Chapter\ 3\ Files/docker-co
 
 After doing an install if you wish to change the password to the elastic username you can use the following command: 
 
-NOTE: You will need to run this command with an account that can access /opt/lme. 
+NOTE: You will need to run this command with an account that can access /opt/lme if you can't sudo the user account will at least need to be able to access the certs located in the command. 
 
 ```
-curl -X POST "https://127.0.0.1:9200/_security/user/elastic/_password" -H "Content-Type: application/json" -d'
+sudo curl -X POST "https://127.0.0.1:9200/_security/user/elastic/_password" -H "Content-Type: application/json" -d'
 {
   "password" : "newpassword"
 }' --cacert /opt/lme/Chapter\ 3\ Files/certs/root-ca.crt -u elastic:currentpassword

--- a/docs/markdown/reference/troubleshooting.md
+++ b/docs/markdown/reference/troubleshooting.md
@@ -309,3 +309,17 @@ To Start LME:
 ```
 sudo docker stack deploy lme --compose-file /opt/lme/Chapter\ 3\ Files/docker-compose-stack-live.yml
 ```
+## Using API
+
+### Changing elastic Username Password
+
+After doing an install if you wish to change the password to the elastic username you can use the following command: 
+
+```
+curl -X POST "https://127.0.0.1:9200/_security/user/elastic/_password" -H "Content-Type: application/json" -d'
+{
+  "password" : "newpassword"
+}' --cacert /opt/lme/Chapter\ 3\ Files/certs/root-ca.crt -u elastic:currentpassword
+```
+
+Replace 'currentpassword' with your current password and 'newpassword' with the password you would like to change it to.


### PR DESCRIPTION
We have decided to remove the 'old password' logic from the install script as elastic already provides the ability to change the password to whatever you want using the API. 

This update to the toubleshooting.md provides guidance on changing the password to the username 'elastic'

I tested this on ls1 in our test environment. Please feel free to test. You dont need to un-install or anything like that. Just run the command. You may need to run it with administrative priv's if your regular account doesn't have access to /opt/lme. the command needs to be able to utilize the certs.