### PR TITLE
git based deployment versioning and other deploy.sh improvements

### DIFF
--- a/Chapter 3 Files/dashboard_update.sh
+++ b/Chapter 3 Files/dashboard_update.sh
@@ -4,11 +4,12 @@ IFS=$'\n'
 Dashboards="$(ls -1 ${LME_DIR}Chapter\ 4\ Files/dashboards/*.ndjson)"
 echo $Dashboards
 
+
 if [ -r /opt/lme/lme.conf ]; then
   #reference this file as a source
   . /opt/lme/lme.conf
   #check if the version number is equal to the one we want
-  if [ "$version" == "1.2.0" ]; then
+  if [ "$version" == "1.3.0" ]; then
     echo -e "\e[32m[X]\e[0m Updating from git repo"
     git -C /opt/lme/ pull
     #make sure the hostname variable is present
@@ -18,10 +19,14 @@ if [ -r /opt/lme/lme.conf ]; then
       echo -e "\e[32m[X]\e[0m Uploading the new dashboards to Kibana"
       for db in ${Dashboards};
       do
-        echo -e "\e[32m[X]\e[0m Uploading ${db%%*.} dashboard"
+        echo -e "\e[32m[X]\e[0m Uploading ${db%%*.} dashboard\n"
         curl -X POST -k --user dashboard_update:dashboardupdatepassword -H 'kbn-xsrf: true' --form file="@${dashbaord_dir}/${db}" "https://127.0.0.1/api/saved_objects/_import?overwrite=true"
+        echo
       done
 
     fi
+  else 
+    echo "!!Upgrade to 1.3.0!!"
   fi
+
 fi

--- a/Chapter 3 Files/deploy.sh
+++ b/Chapter 3 Files/deploy.sh
@@ -4,7 +4,7 @@
 ############################
 # This script configures a host for LME including generating certificates and populating configuration files.
 
-# Put the latest version number here
+REQUIRED_BINARIES=(curl zip net-tools jq)
 
 DATE="$(date '+%Y-%m-%d-%H:%M:%S')"
 
@@ -697,7 +697,7 @@ function install() {
   apt update && apt upgrade -y
 
   echo -e "\e[32m[X]\e[0m Installing prerequisites"
-  apt install curl zip net-tools -y -q
+  apt install ${REQUIRED_BINARIES[*]} -y -q
 
   if [ -f /var/run/reboot-required ]; then
     echo -e "\e[31m[!]\e[0m A reboot is required in order to proceed with the install."
@@ -1062,6 +1062,8 @@ if [[ "$DIR" != "/opt/lme/Chapter 3 Files" ]]; then
   echo -e "\e[31m[!]\e[0m The deploy script is not currently within the correct path, please ensure that LME is located in /opt/lme for installation"
   exit 1
 fi
+
+#check all required binaries are installed
 
 #Change current working directory so relative filepaths work
 cd "$DIR" || exit

--- a/Chapter 3 Files/deploy.sh
+++ b/Chapter 3 Files/deploy.sh
@@ -4,9 +4,48 @@
 ############################
 # This script configures a host for LME including generating certificates and populating configuration files.
 
-REQUIRED_BINARIES=(curl zip net-tools jq)
+REQUIRED_PACKS=(curl zip net-tools jq)
 
 DATE="$(date '+%Y-%m-%d-%H:%M:%S')"
+
+#TODO: convert all logging messages to the following formats: 
+ED=`tput setaf 1`
+GREEN=`tput setaf 2`
+YELLOW=`tput setaf 3`
+MAGENTA=`tput setaf 5`
+CYAN=`tput setaf 6`
+BOLD=`tput bold`
+RST=`tput sgr0`
+function msg { echo -e "${CYAN} $@ ${RST}"; }
+function info { echo -e "\e[32m[X]\e[0m $@"; }
+function success { echo -e "${GREEN}[+] $@ ${RST}"; }
+function warn {  echo -e "${YELLOW}[!] $@ ${RST}"; }
+function error { echo -e "${RED}[-] $@ ${RST}"; }
+
+#ready?
+ready() {
+  if [ -z "$1" ]; then
+    str="Are you sure?"
+  else
+    str=$1
+  fi
+  echo $str
+
+  check=""
+  while ! ([ "${check}" = "n" ] || [ "${check}" = "y" ] );
+  do
+  read -e -p " OK [y/n]?" -i "y" check 
+  if [ "${check}" == "n" ]; then
+    echo -e "\e[33m[!]\e[0m Selected **NO** EXITING"
+    exit 1
+  elif [ "${check}" == "y" ]; then
+    #ready check passed by user
+    return
+  else
+    echo -e "\e[33m[!]\e[0m ONLY PROVIDE y or n"
+  fi
+  done
+}
 
 #prompt for y/n
 prompt() {
@@ -17,7 +56,8 @@ prompt() {
   fi
 
   while true; do
-    read -r -p "$str? [Y/n] " input
+    echo -n "$str"
+    read -r -p " [Y/n] " -i "y" input
 
     case $input in
     [yY][eE][sS] | [yY])
@@ -35,13 +75,19 @@ prompt() {
   done
 }
 
+#pull latest version from github or 
+#SET: FORCE_LATEST_VERSION in environment to force a specific version in testing
 function get_latest_version() {
-  #TODO: eventually have this pull from github
-
-  #return:
-  echo -n '1.2.0'
+  if (: "${FORCE_LATEST_VERSION?}") 2>/dev/null;
+  then
+    echo -n "$FORCE_LATEST_VERSION"
+  else
+    curl -sL https://api.github.com/repos/cisagov/lme/releases/latest | jq -r ".tag_name" | sed 's/v//g' | tr -d "\n"
+  fi
   return 0
 }
+
+
 function customlogstashconf() {
   #add option for custom logstash config
   CUSTOM_LOGSTASH_CONF=/opt/lme/Chapter\ 3\ Files/logstash_custom.conf
@@ -408,7 +454,7 @@ function initdockerswarm() {
 }
 
 function pulllme() {
-  echo -e "\e[32m[X]\e[0m Pulling ELK images"
+  info " Pulling ELK images"
   docker compose -f /opt/lme/Chapter\ 3\ Files/docker-compose-stack-live.yml pull
 }
 
@@ -683,13 +729,21 @@ function fixreadability() {
   chown -R 1000:1000 /opt/lme/backups
   chmod -R go-rwx /opt/lme/backups
 
+  #fix chapter 3 files: group and owner should have rx permissions
+  chown 1000:1000 /opt/lme/Chapter\ 3\ Files/
+  chmod ug+rx /opt/lme/Chapter\ 3\ Files
 }
 
-function install() {
-  echo -e "Will execute the following intrusive actions:\n\t- apt update/upgrade\n\t- install docker (please uninstall before proceeding, or indicate skipping the install)\n\t- initialize docker swarm (execute \`sudo docker swarm leave --force\`  before proceeding if you are part of a swarm\n\t- automatic os updates via unattened-upgrades)"
-  read -e -p "Proceed ([y]es/[n]o):" -i "y" check
 
-  if [ "$check" == "n" ]; then
+function install() {
+  echo -e "Will execute the following intrusive actions:\n\t- apt update & upgrade\n\t- install docker (please uninstall before proceeding, or indicate skipping the install)\n\t- initialize docker swarm (execute \`sudo docker swarm leave --force\`  before proceeding if you are part of a swarm\n\t- automatic os updates via unattened-upgrades\n\t- checkout lme directory to latest version, and throw away local changes)"
+
+  prompt "Proceed?"
+  status=$?
+  #user entered no
+  if ! (exit $status);
+  then
+    error "Exiting" 
     return 1
   fi
 
@@ -697,13 +751,14 @@ function install() {
   apt update && apt upgrade -y
 
   echo -e "\e[32m[X]\e[0m Installing prerequisites"
-  apt install ${REQUIRED_BINARIES[*]} -y -q
+  apt install ${REQUIRED_PACKS[*]} -y -q
 
   if [ -f /var/run/reboot-required ]; then
     echo -e "\e[31m[!]\e[0m A reboot is required in order to proceed with the install."
     echo -e "\e[31m[!]\e[0m Please reboot and re-run this script to finish the install."
     exit 1
   fi
+
 
   #enable auto updates if ubuntu
   auto_os_updates
@@ -887,6 +942,7 @@ function upgrade() {
     #reference this file as a source
     . /opt/lme/lme.conf
     #check if the version number is equal to the one we want
+    #NCSC -> CISA
     if [ "$version" == "0.5.1" ]; then
       echo -e "\e[32m[X]\e[0m Updating from git repo"
       git -C /opt/lme/ pull
@@ -951,7 +1007,7 @@ function upgrade() {
       fi
       zipfiles
       fixreadability
-
+    #1.0 -> 1.2.0 or 1.1.0 -> 1.2.0
     elif [ "$version" == "1.0" ]; then
       echo -e "\e[32m[X]\e[0m Backing up config file to: /opt/lme/Chapter\ 3\ Files/backup_config "
       sudo mkdir -p /opt/lme/Chapter\ 3\ Files/backup_config
@@ -977,11 +1033,45 @@ function upgrade() {
       sudo cp -rapf /opt/lme/dashboard_update.sh /opt/lme/dashboard_update.sh.bku
       sudo sed -i "s/\"\$version\" == \"1.0\"/\"\$version\" == \"$latest\"/g" /opt/lme/dashboard_update.sh
 
-      echo -e "\e[32m[X]\e[0m You're on the latest version: $latest!"
+    #1.2.0 -> 1.3.0
+    elif [ "$version" == "1.2.0" ]; then
+
+      #update lme??
+      sudo docker stack rm lme
+
+      msg "Sleeping for one minute to allow Docker actions to complete..."
+      sleep 1m
+
+      pulllme
+
+      info "Deploy LME"
+      deploylme
+
+      info "Copying lme.conf -> lme.conf.bku"
+      sudo cp -rapf /opt/lme/lme.conf /opt/lme/lme.conf.bku
+      sudo sed -i "s/version=1.0/version=$latest/g" /opt/lme/lme.conf
+
+      info "Copying dashboard_update.sh -> dashboard_update.sh.bku"
+      sudo cp -rapf /opt/lme/dashboard_update.sh /opt/lme/dashboard_update.sh.bku
+
+      info "Setting up new dashboard_update.sh"
+      sudo cp -rapf /opt/lme/Chapter\ 3\ Files/dashboard_update.sh /opt/lme/dashboard_update.sh
+      old_password=$(grep -P -o "(?<=dashboard_update:)[0-9a-zA-Z]+ " /opt/lme/dashboard_update.sh.bku)
+      sudo sed -i "s/dashboardupdatepassword/$old_password/g" /opt/lme/dashboard_update.sh
+
+      #update VERSION NUMBER
+      info "Updating Version to $latest"
+      sudo cp -rapf /opt/lme/lme.conf /opt/lme/lme.conf.bku
+      sudo sed -i -E "s/version=[0-9]+\.[0-9]+\.[0-9]+/version=$latest/g" /opt/lme/lme.conf
+      chmod u+rwx /opt/lme/dashboard_update.sh
+
+      info "Updating dashbaords"
+      sudo /opt/lme/dashboard_update.sh
+
     elif [ "$version" == $latest ]; then
-      echo -e "\e[32m[X]\e[0m You're on the latest version!"
+      info "You're on the latest version!"
     else
-      echo -e "\e[31m[!]\e[0m Updating directly to LME 1.0 from versions prior to 0.5.1 is not supported. Update to 0.5.1 first."
+      error "Updating directly to LME 1.0 from versions prior to 0.5.1 is not supported. Update to 0.5.1 first."
     fi
   fi
 }
@@ -1064,9 +1154,29 @@ if [[ "$DIR" != "/opt/lme/Chapter 3 Files" ]]; then
 fi
 
 #check all required binaries are installed
+missing_pkgs=()
+for pkg in ${REQUIRED_PACKS[*]};
+do
+  #https://stackoverflow.com/a/10439058
+  PKG_OK=$(dpkg-query -W --showformat='${Status}\n' $pkg 2>/dev/null | grep "install ok installed")
+  if [ "" = "$PKG_OK" ]; then
+    missing_pkgs+=($pkg)
+  fi
+done
+#download missing packages
+if [ ${#missing_pkgs[@]} -gt 0 ];
+then
+  ready "Will install the following packages: ${missing_pkgs[*]}. These are required for LME." 
+  sudo apt-get update
+  #confirm install
+  sudo apt-get --yes install ${missing_pkgs[*]}
+fi
 
 #Change current working directory so relative filepaths work
 cd "$DIR" || exit
+
+#TESTING Example BELOW:
+#export FORCE_LATEST_VERSION=1.3.0
 
 #What action is the user wanting to perform
 if [ "$1" == "" ]; then


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##
  - Adds git control into LME's version process
    - testing variable: FORCE_LATEST_VERSION, can be set so a specific version can be passed in the environment during testing: 
      - TO TEST upgrading:
      ```
      export FORCE_LATEST_VERSION="1.2.0"
      sudo -E ./deploy.sh install
      sudo -E ./deploy.sh upgrade
      ```
      - To Test Clean Install: 
       ```
      export FORCE_LATEST_VERSION="1.3.0"
      sudo -E ./deploy.sh install
      ```
    - checkout LME directory to latest version
  
  - fixes "bug" in deploy.sh: 
    - makes it so that the permissions of `Chapter\ 3\ Files` directory are preseserved!

 - upgrade function with 1.2.0 -> 1.3.0, upgrade path
 
 - adds various features to deploy.sh:
    - makes logging wrappers
    - better prompt on install
    - ready check, to confirm user is ok with an action before proceeding
    - Checks for required packages during run of deploy.sh. SHould help if we ever add a package later to the deployment script



## 💭 Motivation and context ##

LME versioning should be tracked automatically via git and the installed version should be automatically tracked via git. 
There was a little QOL of changes need for deploy.sh as well. 

Solves: https://github.com/cisagov/LME/issues/69

## 🧪 Testing ##
Tested on a clean install of 1.2.0 -> upgrade 1.3.0
tested on a clean install of 1.3.0 on this branch

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [ ] All new and existing tests pass.
