### PR TITLE
Updated troubleshooting guide to account for index management

### DIFF
--- a/docs/markdown/reference/troubleshooting.md
+++ b/docs/markdown/reference/troubleshooting.md
@@ -327,3 +327,46 @@ sudo curl -X POST "https://127.0.0.1:9200/_security/user/elastic/_password" -H "
 Replace 'currentpassword' with your current password and 'newpassword' with the password you would like to change it to. 
 
 Utilize environment variables in place of currentpassword and newpassword to avoid saving your password to console history. If not we recommend you clear your history after changing the password with ```history -c```
+
+## Index Management
+
+If you are having issues with your hard disk filling up too fast you can use these steps to delete logs earlier than your current settings.
+
+1. **Log in to Elastic**
+   - Access the Elastic platform and log in with your credentials.
+
+2. **Navigate to Management Section**
+   - In the main menu, click on "Management."
+
+3. **Access Stack Management**
+   - Within the Management section, select "Stack Management."
+
+4. **Select Index Lifecycle Policies**
+   - In Stack Management, find and choose "Index Lifecycle Policies."
+
+5. **Choose the Relevant ILM Policy**
+   - From the list, select `lme_ilm_policy` for editing.
+
+6. **Adjust the Hot Phase Settings**
+   - Navigate to the 'Hot Phase' section.
+   - Expand 'Advanced settings'.
+   - Uncheck "Use recommended defaults."
+   - Change the "Maximum age" setting to match your desired delete phase duration.
+
+     > **Note:** Aligning the maximum age in the hot phase with the delete phase ensures consistency in data retention.
+
+7. **Adjust the Delete Phase Settings**
+   - Scroll to the 'Delete Phase' section.
+   - Find and adjust the "Move data into phase when:" setting.
+   - Ensure the delete phase duration matches the maximum age set in the hot phase.
+
+     > **Note:** This setting determines the deletion timing of your logs. Ensure to back up necessary data before changes.
+
+8. **Save Changes**
+   - Save the adjustments you've made.
+
+9. **Verify the Changes**
+   - Review and ensure that the changes are functioning as intended.
+
+10. **Document the Changes**
+    - Record the modifications for future reference.

--- a/docs/markdown/reference/troubleshooting.md
+++ b/docs/markdown/reference/troubleshooting.md
@@ -370,3 +370,9 @@ If you are having issues with your hard disk filling up too fast you can use the
 
 10. **Document the Changes**
     - Record the modifications for future reference.
+
+You can also manually delete an index using the following command: 
+
+```sudo curl -X DELETE "https://127.0.0.1:9200/your_index_name" -H "Content-Type: application/json" --cacert /opt/lme/Chapter\ 3\ Files/certs/root-ca.crt -u elastic:yourpassword
+```
+    > **Note:** Ensure this is not your current winlogbeat index in use. You should only delete indices that have already rolled over. i.e. if you have index winlogbeat-00001 and winlogbeat-00002 do NOT delete winlogbeat-00002.

--- a/docs/markdown/reference/troubleshooting.md
+++ b/docs/markdown/reference/troubleshooting.md
@@ -375,6 +375,7 @@ You can also manually delete an index using the following command:
 
 ```
 curl -X DELETE "https://127.0.0.1:9200/your_index_name" -H "Content-Type: application/json" --cacert /opt/lme/Chapter\ 3\ Files/certs/root-ca.crt -u elastic:yourpassword
-```
+``````
+    **Note:** Ensure this is not your current winlogbeat index in use. You should only delete indices that have already rolled over. i.e. if you have index winlogbeat-00001 and winlogbeat-00002 do NOT delete winlogbeat-00002.
 
-    > **Note:** Ensure this is not your current winlogbeat index in use. You should only delete indices that have already rolled over. i.e. if you have index winlogbeat-00001 and winlogbeat-00002 do NOT delete winlogbeat-00002.
+

--- a/docs/markdown/reference/troubleshooting.md
+++ b/docs/markdown/reference/troubleshooting.md
@@ -378,4 +378,11 @@ curl -X DELETE "https://127.0.0.1:9200/your_index_name" -H "Content-Type: applic
 ```
 > **Note:**    Ensure this is not your current winlogbeat index in use. You should only delete indices that have already rolled over. i.e. if you have index winlogbeat-00001 and winlogbeat-00002 do NOT delete winlogbeat-00002.
 
+If you only have one index you can manually force a rollover with the following command: 
+
+```
+curl -X POST "https://127.0.0.1:9200/winlogbeat-alias/_rollover" -H "Content-Type: application/json" --cacert /opt/lme/Chapter\ 3\ Files/certs/root-ca.crt -u elastic:yourpassword
+```
+
+This will rollover winlogbeat-00001 and create winlogbeat-00002. You can now manually delete 00001. 
 

--- a/docs/markdown/reference/troubleshooting.md
+++ b/docs/markdown/reference/troubleshooting.md
@@ -375,7 +375,7 @@ You can also manually delete an index using the following command:
 
 ```
 curl -X DELETE "https://127.0.0.1:9200/your_index_name" -H "Content-Type: application/json" --cacert /opt/lme/Chapter\ 3\ Files/certs/root-ca.crt -u elastic:yourpassword
-``````
-    **Note:** Ensure this is not your current winlogbeat index in use. You should only delete indices that have already rolled over. i.e. if you have index winlogbeat-00001 and winlogbeat-00002 do NOT delete winlogbeat-00002.
+```
+> **Note:**    Ensure this is not your current winlogbeat index in use. You should only delete indices that have already rolled over. i.e. if you have index winlogbeat-00001 and winlogbeat-00002 do NOT delete winlogbeat-00002.
 
 

--- a/docs/markdown/reference/troubleshooting.md
+++ b/docs/markdown/reference/troubleshooting.md
@@ -336,7 +336,7 @@ If you are having issues with your hard disk filling up too fast you can use the
    - Access the Elastic platform and log in with your credentials.
 
 2. **Navigate to Management Section**
-   - In the main menu, click on "Management."
+   - In the main menu, scroll down to "Management."
 
 3. **Access Stack Management**
    - Within the Management section, select "Stack Management."
@@ -366,7 +366,7 @@ If you are having issues with your hard disk filling up too fast you can use the
    - Save the adjustments you've made.
 
 9. **Verify the Changes**
-   - Review and ensure that the changes are functioning as intended.
+   - Review and ensure that the changes are functioning as intended. Indices may not delete immediately - allow time for job to run.
 
 10. **Document the Changes**
     - Record the modifications for future reference.

--- a/docs/markdown/reference/troubleshooting.md
+++ b/docs/markdown/reference/troubleshooting.md
@@ -373,6 +373,8 @@ If you are having issues with your hard disk filling up too fast you can use the
 
 You can also manually delete an index using the following command: 
 
-```sudo curl -X DELETE "https://127.0.0.1:9200/your_index_name" -H "Content-Type: application/json" --cacert /opt/lme/Chapter\ 3\ Files/certs/root-ca.crt -u elastic:yourpassword
 ```
+curl -X DELETE "https://127.0.0.1:9200/your_index_name" -H "Content-Type: application/json" --cacert /opt/lme/Chapter\ 3\ Files/certs/root-ca.crt -u elastic:yourpassword
+```
+
     > **Note:** Ensure this is not your current winlogbeat index in use. You should only delete indices that have already rolled over. i.e. if you have index winlogbeat-00001 and winlogbeat-00002 do NOT delete winlogbeat-00002.

--- a/docs/markdown/reference/troubleshooting.md
+++ b/docs/markdown/reference/troubleshooting.md
@@ -371,7 +371,7 @@ If you are having issues with your hard disk filling up too fast you can use the
 10. **Document the Changes**
     - Record the modifications for future reference.
 
-You can also manually delete an index using the following command: 
+You can also manually delete an index from the GUI under Management > Index Managment or by using the following command: 
 
 ```
 curl -X DELETE "https://127.0.0.1:9200/your_index_name" -H "Content-Type: application/json" --cacert /opt/lme/Chapter\ 3\ Files/certs/root-ca.crt -u elastic:yourpassword


### PR DESCRIPTION
# Resolves #126  #

## 🗣 Description ##

This provides users with troubleshooting steps for index management. If their hard disk is filling up and they need to know how to delete indices / change the auto rollover policy to better adjust to their environment after they have a good feel for how many logs they get.


## 🧪 Testing ##

Tested steps to manually setting the ILM policy to 5 minutes instead of 30 days. Here's an image after I let it sit for 20 minutes or so: 


![index](https://github.com/cisagov/LME/assets/149685528/6353c519-cb09-4bd5-972d-b54178d57858)

For every next number 5 minutes passed, the rollover policy took place, and created a new index. The rollover policy, and delete policy can be adjusted to whatever best meets the customers needs after they determine how much space they use up.

What is Rollover?

Rollover is when an index goes from "active" to "inactive"  So, once its been 30 days (or whatever is set) or the index reaches 50GB in size it will become inactive, but still retain its data. i.e. winlogbeat1 becomes inactive, retains its data (if it hasn't hit the delete threshold) and then winlogbeat2 is created. winlogbeat2 is now where the latest event logs are written. This is a 'rollover' and allows you delete specific indexes without having to delete all your data.  Using curl I could delete winlogbeat1 and winlogbeat2 and keep winlogbeat3, etc. By changing your rollover time or size you can become granular with this management process if you're having disk space issues.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

