### PR TITLE
Update retention function to fix retention policy bug

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -19,13 +19,17 @@
 <!-- see how your change affects other areas of the code, etc. -->
 
 ## ✅ Pre-approval checklist ##
-
+- [ ] There is a [gitIssue](https://github.com/cisagov/LME/issues) that this PR resolves
+- [ ] The PR's base branch has been modified to be the proper branch. 
 - [ ] Changes are limited to a single goal **AND** 
-      the title reflects this in a clear human readable format
+      the title reflects this in a clear human readable format for the release notes
 - [ ] I have read and agree to LME's [CONTRIBUTING.md](https://github.com/cisagov/LME/CONTRIBUTING.md) document.
 - [ ] The PR adheres to LME's requirements in [RELEASES.md](https://github.com/cisagov/LME/RELEASES.md#steps-to-submit-a-PR)
 - [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
 - [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
+- [ ] The PR is labeled with `feat` for an added new feature, `update` for an update, **OR** `fix` for a fix.
+- [ ] The PR contains `Resolves #<issue #>` so that merging it closes out the corresponding issue.  For example `Resolves #132`.
+
 
 ## ✅ Pre-merge Checklist
 

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -19,17 +19,13 @@
 <!-- see how your change affects other areas of the code, etc. -->
 
 ## ✅ Pre-approval checklist ##
-- [ ] There is a [gitIssue](https://github.com/cisagov/LME/issues) that this PR resolves
-- [ ] The PR's base branch has been modified to be the proper branch. 
+
 - [ ] Changes are limited to a single goal **AND** 
-      the title reflects this in a clear human readable format for the release notes
+      the title reflects this in a clear human readable format
 - [ ] I have read and agree to LME's [CONTRIBUTING.md](https://github.com/cisagov/LME/CONTRIBUTING.md) document.
 - [ ] The PR adheres to LME's requirements in [RELEASES.md](https://github.com/cisagov/LME/RELEASES.md#steps-to-submit-a-PR)
 - [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
 - [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
-- [ ] The PR is labeled with `feat` for an added new feature, `update` for an update, **OR** `fix` for a fix.
-- [ ] The PR contains `Resolves #<issue #>` so that merging it closes out the corresponding issue.  For example `Resolves #132`.
-
 
 ## ✅ Pre-merge Checklist
 
@@ -40,4 +36,3 @@
 
 - [ ] Squash all commits into one PR level commit 
 - [ ] Delete the branch to keep down number of branches
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,8 @@ All PRs will be tested, vetted, and reviewed by our team before being merged wit
 ### Steps to submit a PR
 	- All PRs should request merges back into LME's *CLOSEST* Major or Minor upcoming release branch `release-X.Y.Z`. This will be viewable in the branch list on Github. You can also refer to our release documentation for guidance. 
   - If the PR corresponds to an issue we are already tracking on LME's public Github [project](https://github.com/orgs/cisagov/projects/68), please comment the PR in the issue, and we will update the issue. 
-  - If the PR does not have an issue, please create a new issue and name your branch according to the conventions [here](#branch-naming-conventions). Add a comment at the top of the pull request describing the PR and how it fits into LME's project/code. If the PR follows our other requirements listed here, we'll add it into our public project linked previously.
+  - If the PR does not have an issue, please create a new issue and name your branch according to the conventions [here](#branch-naming-conventions). Add a human readable title describing the PR and how it fits into LME's project/code. If the PR follows our other requirements listed here, we'll add it into our public project linked previously.
+  - Add the label `feat` for an added new feature, `update` for an update, **or** `fix` for a fix.
   - We'll work with you to mold it to our development goals/process, so your work can be merged into LME and your Github profile gets credit for the contributions. 
   - Before merging we request that all commits be squashed into one commit. This way your changes to the repository are tracked, but our `git log` history does not rapidly expand. 
   - Thanks for wanting to submit and develop improvements for LME!!

--- a/Chapter 3 Files/deploy.sh
+++ b/Chapter 3 Files/deploy.sh
@@ -534,35 +534,35 @@ function pipelineupdate() {
 }
 
 function data_retention() {
-  #show ext4 disk
+  # Show ext4 disk
   DF_OUTPUT="$(df -h -l -t ext4 --output=source,size /var/lib/docker)"
 
-  #pull dev name
+  # Pull device name
   DISK_DEV="$(echo "$DF_OUTPUT" | grep -Po '[0-9]+G')"
 
-  #pull dev size
-  DISK_SIZE_ROUND="${DISK_DEV/G/}"
-
-  #lets do math to get 75% (%80 is low watermark for ES but as curator uses this we want to delete data *before* the disk gets full)
-  DISK_80=$((DISK_SIZE_ROUND * 80 / 100))
+  # Pull device size
+  DISK_SIZE="${DISK_DEV/G/}"
 
   echo -e "\e[32m[X]\e[0m We think your main disk is $DISK_DEV"
 
-  if [ "$DISK_80" -lt 30 ]; then
-    echo -e "\e[31m[!]\e[0m LME Requires 128GB of space usable for log retention - exiting"
-    exit 1
-  elif [ "$DISK_80" -ge 90 ] && [ "$DISK_80" -le 179 ]; then
+  if [ "$DISK_SIZE" -lt 128 ]; then
+    echo -e "\e[33m[!]\e[0m Warning: Disk size less than 128GB, recommend a larger disk for production environments"
+    sleep 3
     RETENTION="30"
-  elif [ "$DISK_80" -ge 180 ] && [ "$DISK_80" -le 359 ]; then
+  elif [ "$DISK_SIZE" -ge 128 ] && [ "$DISK_SIZE" -le 179 ]; then
+    RETENTION="45"
+  elif [ "$DISK_SIZE" -ge 180 ] && [ "$DISK_SIZE" -le 359 ]; then
     RETENTION="90"
-  elif [ "$DISK_80" -ge 360 ] && [ "$DISK_80" -le 539 ]; then
+  elif [ "$DISK_SIZE" -ge 360 ] && [ "$DISK_SIZE" -le 539 ]; then
     RETENTION="180"
-  elif [ "$DISK_80" -ge 540 ] && [ "$DISK_80" -le 719 ]; then
+  elif [ "$DISK_SIZE" -ge 540 ] && [ "$DISK_SIZE" -le 719 ]; then
     RETENTION="270"
-  elif [ "$DISK_80" -ge 720 ]; then
+  elif [ "$DISK_SIZE" -ge 720 ]; then
     RETENTION="365"
   else
-    echo -e "\e[31m[!]\e[0m Unable to determine retention policy - exiting"
+    echo -e "\e[31m[!]\e[0m Unable to determine retention policy - exiting."
+    echo -e "Please check the disk size. The disk size detected was: $DISK_DEV."
+    echo -e "Ensure that the script detected the disk size correctly"
     exit 1
   fi
 

--- a/Chapter 3 Files/deploy.sh
+++ b/Chapter 3 Files/deploy.sh
@@ -549,7 +549,7 @@ function data_retention() {
     exit 1
   fi
 
-  echo -e "\e[32m[X]\e[0m We think your main disk is $DISK_DEV"
+  echo -e "\e[32m[X]\e[0m We think your main disk is $DISK_DEV and its size is $DISK_SIZE gigabytes"
 
   if [ "$DISK_SIZE" -lt 128 ]; then
     echo -e "\e[33m[!]\e[0m Warning: Disk size less than 128GB, recommend a larger disk for production environments. Install continuing..."

--- a/Chapter 3 Files/deploy.sh
+++ b/Chapter 3 Files/deploy.sh
@@ -543,6 +543,12 @@ function data_retention() {
   # Pull device size
   DISK_SIZE="${DISK_DEV/G/}"
 
+  # Check if DISK_SIZE is empty or not a number
+  if ! [[ "$DISK_SIZE" =~ ^[0-9]+$ ]]; then
+    echo -e "\e[31m[!]\e[0m DISK_SIZE not an integer or is empty - exiting."
+    exit 1
+  fi
+
   echo -e "\e[32m[X]\e[0m We think your main disk is $DISK_DEV"
 
   if [ "$DISK_SIZE" -lt 128 ]; then
@@ -560,9 +566,7 @@ function data_retention() {
   elif [ "$DISK_SIZE" -ge 720 ]; then
     RETENTION="365"
   else
-    echo -e "\e[31m[!]\e[0m Unable to determine retention policy - exiting."
-    echo -e "Please check the disk size. The disk size detected was: $DISK_DEV."
-    echo -e "Ensure that the script detected the disk size correctly"
+    echo -e "\e[31m[!]\e[0m Unable to determine disk size - exiting."
     exit 1
   fi
 

--- a/Chapter 3 Files/deploy.sh
+++ b/Chapter 3 Files/deploy.sh
@@ -546,7 +546,7 @@ function data_retention() {
   echo -e "\e[32m[X]\e[0m We think your main disk is $DISK_DEV"
 
   if [ "$DISK_SIZE" -lt 128 ]; then
-    echo -e "\e[33m[!]\e[0m Warning: Disk size less than 128GB, recommend a larger disk for production environments"
+    echo -e "\e[33m[!]\e[0m Warning: Disk size less than 128GB, recommend a larger disk for production environments. Install continuing..."
     sleep 3
     RETENTION="30"
   elif [ "$DISK_SIZE" -ge 128 ] && [ "$DISK_SIZE" -le 179 ]; then


### PR DESCRIPTION
# Resolves #104  #

## 🗣 Description ##

This logic does a few things 
1. There is no size that "fails" the install. All disk sizes are accepted.
2. If their disk size is less than 128, the user is presented a warning saying larger disk sizes are recommended for production environments.
3. I have removed the 80% logic of the disk space. I think this logic will be confusing to people wondering why their 128GB disk is not actually considered 128GB and provides no real functional benefit. Open to a counter argument.
4. I also added some additional echo statements to the 'fail' section of the logic to try and provide more information to the user on why it failed. Versus just saying "Couldn't determine retention policy"

## 💭 Motivation and context ##

Fixes install bug if users have a disk size between 31-89 GB's.

## 🧪 Testing ##

Nothing changing other than retention policy. A simple deploy.sh uninstall and then deploy.sh install should successfully test install functions properly. You can then log into elastic and go to Index Management -> Index lifecycle policies and ensure the lme policy has correctly set "delete" phase to occur after 30/45/90 days etc based on your disk size.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.


