### PR TITLE
Update retention function to fix retention policy bug

### DIFF
--- a/Chapter 3 Files/deploy.sh
+++ b/Chapter 3 Files/deploy.sh
@@ -534,35 +534,39 @@ function pipelineupdate() {
 }
 
 function data_retention() {
-  #show ext4 disk
+  # Show ext4 disk
   DF_OUTPUT="$(df -h -l -t ext4 --output=source,size /var/lib/docker)"
 
-  #pull dev name
+  # Pull device name
   DISK_DEV="$(echo "$DF_OUTPUT" | grep -Po '[0-9]+G')"
 
-  #pull dev size
-  DISK_SIZE_ROUND="${DISK_DEV/G/}"
+  # Pull device size
+  DISK_SIZE="${DISK_DEV/G/}"
 
-  #lets do math to get 75% (%80 is low watermark for ES but as curator uses this we want to delete data *before* the disk gets full)
-  DISK_80=$((DISK_SIZE_ROUND * 80 / 100))
-
-  echo -e "\e[32m[X]\e[0m We think your main disk is $DISK_DEV"
-
-  if [ "$DISK_80" -lt 30 ]; then
-    echo -e "\e[31m[!]\e[0m LME Requires 128GB of space usable for log retention - exiting"
+  # Check if DISK_SIZE is empty or not a number
+  if ! [[ "$DISK_SIZE" =~ ^[0-9]+$ ]]; then
+    echo -e "\e[31m[!]\e[0m DISK_SIZE not an integer or is empty - exiting."
     exit 1
-  elif [ "$DISK_80" -ge 90 ] && [ "$DISK_80" -le 179 ]; then
+  fi
+
+  echo -e "\e[32m[X]\e[0m We think your main disk is $DISK_DEV and its size is $DISK_SIZE gigabytes"
+
+  if [ "$DISK_SIZE" -lt 128 ]; then
+    echo -e "\e[33m[!]\e[0m Warning: Disk size less than 128GB, recommend a larger disk for production environments. Install continuing..."
+    sleep 3
     RETENTION="30"
-  elif [ "$DISK_80" -ge 180 ] && [ "$DISK_80" -le 359 ]; then
+  elif [ "$DISK_SIZE" -ge 128 ] && [ "$DISK_SIZE" -le 179 ]; then
+    RETENTION="45"
+  elif [ "$DISK_SIZE" -ge 180 ] && [ "$DISK_SIZE" -le 359 ]; then
     RETENTION="90"
-  elif [ "$DISK_80" -ge 360 ] && [ "$DISK_80" -le 539 ]; then
+  elif [ "$DISK_SIZE" -ge 360 ] && [ "$DISK_SIZE" -le 539 ]; then
     RETENTION="180"
-  elif [ "$DISK_80" -ge 540 ] && [ "$DISK_80" -le 719 ]; then
+  elif [ "$DISK_SIZE" -ge 540 ] && [ "$DISK_SIZE" -le 719 ]; then
     RETENTION="270"
-  elif [ "$DISK_80" -ge 720 ]; then
+  elif [ "$DISK_SIZE" -ge 720 ]; then
     RETENTION="365"
   else
-    echo -e "\e[31m[!]\e[0m Unable to determine retention policy - exiting"
+    echo -e "\e[31m[!]\e[0m Unable to determine disk size - exiting."
     exit 1
   fi
 


### PR DESCRIPTION
# Resolves #104  #

## 🗣 Description ##

This logic does a few things 
1. There is no size that "fails" the install. All disk sizes are accepted.
2. If their disk size is less than 128, the user is presented a warning saying larger disk sizes are recommended for production environments.
3. I have removed the 80% logic of the disk space. I think this logic will be confusing to people wondering why their 128GB disk is not actually considered 128GB and provides no real functional benefit. Open to a counter argument.
4. I also added some additional echo statements to the 'fail' section of the logic to try and provide more information to the user on why it failed. Versus just saying "Couldn't determine retention policy"

## 💭 Motivation and context ##

Fixes install bug if users have a disk size between 31-89 GB's.

## 🧪 Testing ##

Nothing changing other than retention policy. A simple deploy.sh uninstall and then deploy.sh install should successfully test install functions properly. You can then log into elastic and go to Index Management -> Index lifecycle policies and ensure the lme policy has correctly set "delete" phase to occur after 30/45/90 days etc based on your disk size.

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.


