### PR TITLE
Automatically Add Tags to Azure Resources

### DIFF
--- a/testing/SetupTestbed.ps1
+++ b/testing/SetupTestbed.ps1
@@ -97,6 +97,10 @@ $Ports = 22, 3389, 443, 9200, 5044
 $Priorities = 1001, 1002, 1003, 1004, 1005
 $Protocols = "Tcp", "Tcp", "Tcp", "Tcp", "Tcp"
 
+# Variables used for Azure tags
+$CurrentUser = $(az account show | ConvertFrom-Json).user.name
+$Today = $(Get-Date).ToString("yyyy-MM-dd")
+$Project = "LME"
 
 function Get-RandomPassword {
     param (
@@ -173,7 +177,8 @@ function Set-NetworkRules {
             --source-address-prefixes $AllowedSourcesList `
             --destination-address-prefixes '*' `
             --destination-port-ranges $port `
-            --description "Allow inbound from $sources on $port via $protocol connections."
+            --description "Allow inbound from $sources on $port via $protocol connections." `
+            --tags project=$Project created=$Today createdBy=$CurrentUser
         Write-Output $networkRuleResponse
     }
 }
@@ -232,11 +237,9 @@ if (-Not $NoPrompt) {
 # Setup resource group #
 ########################
 Write-Output "`nCreating resource group..."
-$CurrentUser = $(az account show | ConvertFrom-Json).user.name
-$Today = $(Get-Date).ToString("yyyy-MM-dd")
 $createResourceGroupResponse = az group create --name $ResourceGroup `
     --location $Location `
-    --tags project="LME" created=$Today createdBy=$CurrentUser
+    --tags project=$Project created=$Today createdBy=$CurrentUser
 Write-Output $createResourceGroupResponse
 
 #################
@@ -248,13 +251,15 @@ $createVirtualNetworkResponse = az network vnet create --resource-group $Resourc
     --name VNet1 `
     --address-prefix $VNetPrefix `
     --subnet-name SNet1 `
-    --subnet-prefix $SubnetPrefix
+    --subnet-prefix $SubnetPrefix `
+    --tags project=$Project created=$Today createdBy=$CurrentUser
 Write-Output $createVirtualNetworkResponse
 
 Write-Output "`nCreating nsg..."
 $createNsgResponse = az network nsg create --name NSG1 `
     --resource-group $ResourceGroup `
-    --location $Location
+    --location $Location `
+    --tags project=$Project created=$Today createdBy=$CurrentUser
 Write-Output $createNsgResponse
 
 Set-NetworkRules -AllowedSourcesList $AllowedSourcesList
@@ -280,7 +285,8 @@ $createLs1Response = az vm create `
     --public-ip-sku Standard `
     --size Standard_E2d_v4 `
     --os-disk-size-gb 128 `
-    --private-ip-address $LsIP
+    --private-ip-address $LsIP `
+    --tags project=$Project created=$Today createdBy=$CurrentUser
 Write-Output $createLs1Response
 
 if (-Not $LinuxOnly){
@@ -295,7 +301,8 @@ if (-Not $LinuxOnly){
         --vnet-name VNet1 `
         --subnet SNet1 `
         --public-ip-sku Standard `
-        --private-ip-address $DcIP
+        --private-ip-address $DcIP `
+        --tags project=$Project created=$Today createdBy=$CurrentUser
     Write-Output $createDc1Response
     for ($i = 1; $i -le $NumClients; $i++) {
         Write-Output "`nCreating C$i..."
@@ -308,7 +315,8 @@ if (-Not $LinuxOnly){
             --admin-password $VMPassword `
             --vnet-name VNet1 `
             --subnet SNet1 `
-            --public-ip-sku Standard
+            --public-ip-sku Standard `
+            --tags project=$Project created=$Today createdBy=$CurrentUser
         Write-Output $createClientResponse
     }
 }

--- a/testing/SetupTestbed.ps1
+++ b/testing/SetupTestbed.ps1
@@ -232,7 +232,11 @@ if (-Not $NoPrompt) {
 # Setup resource group #
 ########################
 Write-Output "`nCreating resource group..."
-$createResourceGroupResponse = az group create --name $ResourceGroup --location $Location
+$CurrentUser = $(az account show | ConvertFrom-Json).user.name
+$Today = $(Get-Date).ToString("yyyy-MM-dd")
+$createResourceGroupResponse = az group create --name $ResourceGroup `
+    --location $Location `
+    --tags project="LME" created=$Today createdBy=$CurrentUser
 Write-Output $createResourceGroupResponse
 
 #################

--- a/testing/configure/azure_scripts/create_blob_container.ps1
+++ b/testing/configure/azure_scripts/create_blob_container.ps1
@@ -53,12 +53,18 @@ $StorageAccountName = New-AzureName -Prefix "st"
 # Generate a container name
 $ContainerName = New-AzureName -Prefix "container"
 
+# Variables used for Azure tags
+$CurrentUser = $(az account show | ConvertFrom-Json).user.name
+$Today = $(Get-Date).ToString("yyyy-MM-dd")
+$Project = "LME"
+
 # Create a new storage account
 az storage account create `
     --name $StorageAccountName `
     --resource-group $ResourceGroup `
     --location $Location `
-    --sku Standard_LRS
+    --sku Standard_LRS `
+    --tags project=$Project created=$Today createdBy=$CurrentUser
 
 # Wait for a moment to ensure the storage account is available
 Start-Sleep -Seconds 10


### PR DESCRIPTION
## 🗣 Description ##
Modify the testing scripts so that all Azure resources they create are automatically tagged with who created them, when they were created, and indicate that they belong to LME.

_PR only affects testing scripts._
## 💭 Motivation and context ##
Should facilitate identifying stale resources and add personal accountability for resource usage.
 
## 🧪 Testing ##
I ran both SetupTestbed.ps1 and InstallTestbed.ps1. Both scripts successfully finished and all Azure resources had the tags as expected.

## 📷 Screenshots ##
![image](https://github.com/cisagov/LME/assets/106177711/6615e2cf-f279-46e9-b46d-820b5472c257)

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [x] All new and existing tests pass.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release.
