### PR TITLE
Create new workflow for automating the release process

### DIFF
--- a/.github/changelog-configuration.json
+++ b/.github/changelog-configuration.json
@@ -1,0 +1,22 @@
+{ 
+  "categories": [
+    {
+      "title": "## What's Added",
+      "labels": ["feat"],
+    },
+    {
+      "title": "## What's Fixed",
+      "labels": ["fix"],
+    },
+    {
+      "title": "## What's Updated",
+      "labels": ["update"],
+    },
+    {
+      "title": "## Uncategorized",
+      "labels": [],
+    },
+  ],
+  "template": "#{{CHANGELOG}}",
+  "pr_template": "* #{{TITLE}} by @#{{AUTHOR}} in ##{{NUMBER}}" 
+}

--- a/.github/workflows/build_release.yaml
+++ b/.github/workflows/build_release.yaml
@@ -1,0 +1,49 @@
+on:
+  workflow_dispatch: 
+    inputs:
+      version:
+        description: "Release version (e.g., 1.1.0)"
+        required: true
+        type: string
+
+name: Build Release
+
+jobs: 
+  build-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Get current date 
+        id: date
+        run: | 
+          echo "date=$(date +'%Y-%m-%d')" >> $GITHUB_ENV
+
+      - name: Build Assets
+        run: git ls-files | zip LME-${{ inputs.version }}.zip -@
+
+      - name: Build Changelog
+        id: release
+        uses: mikepenz/release-changelog-builder-action@v4.1.1
+        with: 
+          toTag: "release-${{ inputs.version }}"
+          configuration: ".github/changelog-configuration.json"
+          failOnError: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Draft Release 
+        uses: softprops/action-gh-release@v0.1.15
+        with:
+          name: LME v${{ inputs.version }}
+          tag_name: v${{ inputs.version }}
+          body: | 
+            ## [${{ inputs.version }}] - Timberrrrr! - ${{ env.date }}
+            ${{ steps.release.outputs.changelog }}
+          files: LME-${{ inputs.version }}.zip
+          draft: true
+          prerelease: false
+          discussion_category_name: "Announcements"
+          generate_release_notes: false
+          fail_on_unmatched_files: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,8 +5,8 @@ on:
         - main
       tags:
         - 'v[0-9]+.[0-9]+.[0-9]+*'  # match basic semver tags
-    pull_request:
-      branches:
+    pull_request:  
+      branches: 
          - main
          - 'release-*'
   
@@ -62,25 +62,4 @@ jobs:
         run: |
           semgrep --config "p/r2c" .
 
-  release:
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: [lint, semgrep-scan]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4.0.0
-
-      - name: Set up tag name
-        id: tag
-        run: echo "::set-output name=tag::${GITHUB_REF##*/}"
-
-      - name: Build
-        run: git ls-files | zip release-${{ steps.tag.outputs.tag }}.zip -@
-
-      - name: Release
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v0.1.15
-        with:
-          files: release-${{ steps.tag.outputs.tag }}.zip
-          draft: true
-          generate_release_notes: true
-          fail_on_unmatched_files: true
+  


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Adds a new workflow build_release.yaml which automates LME's release process. 

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

Our release process is done manually and is about 15 steps long. It is prone to human error and not easily scalable for the team to replicate. 

closes #82 

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

Since GitHub Actions require committing to the main branch I've been testing the new workflow from a forked version of LME. https://github.com/mitchelbaker-cisa/LME

Releases created with the workflow are shown here: https://github.com/mitchelbaker-cisa/LME/releases

I've been testing by creating sample feature PRs, merging these into a release PR, and testing from here to determine if the generated draft release is correct. 

I've tested that the workflow only runs when a pull request prefixed with "release-*" is opened. Still running tests to determine if the workflow runs as expected when new commits are added to a PR, and consequently updates the draft release. (synchronize event)

I've tested that the manual version of this workflow runs after a release PR is merged into main. Draft release is generated as expected, and PRs and organized under respective titles 

## 📷 Screenshots (if appropriate) ##

Example draft release that's created from the new workflow 

![Screenshot (5)](https://github.com/cisagov/LME/assets/149098823/7a286eaf-a313-4b84-acc9-883341138179)

Draft release with `feat`/`fix`/`update` added as labels 

![Screenshot (16)](https://github.com/cisagov/LME/assets/149098823/2458c291-cc8b-4094-ad60-b1d8a0c92bb0)


## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced
      in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [x] Check that parent branch is release-1.4.0
- [x] Further testing needs to be done to ensure changelog is generated from the 'release-*' commit history as opposed to main. 
- [x] Remove configurationJson parameter, create 'configuration.json' file and specify `configuration: "configuration.json"` in the "Build Changelog" step
- [x] Job should only run for pull requests under the following events: opened, synchronize
~~- [ ] If a new PR is added to the release branch, then the draft release should reflect the new commit~~
- [x] If `feat`/`fix`/`update` labels are added to a PR, then they should be grouped under respective titles `What's Added`/`What's Fixed`/`What's Updated`. If a PR does not have a label it will be grouped under `Uncategorized`.
