### PR TITLE
Update and rename replica function to current elastic standards

### DIFF
--- a/Chapter 3 Files/deploy.sh
+++ b/Chapter 3 Files/deploy.sh
@@ -657,13 +657,21 @@ function auto_os_updates() {
   fi
 }
 
-function configelasticsearch() {
+function config_replicas() {
   echo -e "\n\e[32m[X]\e[0m Configuring elasticsearch Replica settings"
 
   #set future index to always have no replicas
-  curl --cacert certs/root-ca.crt --user "elastic:$elastic_user_pass" -X PUT "https://127.0.0.1:9200/_template/number_of_replicas" -H 'Content-Type: application/json' -d' {  "template": "*",  "settings": {    "number_of_replicas": 0  }}'
+  curl --cacert certs/root-ca.crt --user "elastic:$elastic_user_pass" -X PUT "https://127.0.0.1:9200/_index_template/number_of_replicas" -H 'Content-Type: application/json' -d'{
+  "index_patterns": ["*"],
+  "template": {
+    "settings": {
+      "number_of_replicas": 0
+    }
+  },
+  "priority": 1
+}'
   #set all current indices to have 0 replicas
-  curl --cacert certs/root-ca.crt --user "elastic:$elastic_user_pass" -X PUT "https://127.0.0.1:9200/_all/_settings" -H 'Content-Type: application/json' -d '{"index" : {"number_of_replicas" : 0}}'
+  curl --cacert certs/root-ca.crt --user "elastic:$elastic_user_pass" -X PUT "https://127.0.0.1:9200/*/_settings" -H 'Content-Type: application/json' -d '{"index" : {"number_of_replicas" : 0}}'
 }
 
 function writeconfig() {
@@ -858,7 +866,6 @@ function install() {
   pulllme
   deploylme
   setpasswords
-  configelasticsearch
   zipfiles
 
   #pipelines
@@ -872,6 +879,9 @@ function install() {
 
   #bootstrap
   bootstrapindex
+
+  #config replicas
+  config_replicas
 
   #create config file
   writeconfig

--- a/Chapter 3 Files/deploy.sh
+++ b/Chapter 3 Files/deploy.sh
@@ -671,7 +671,7 @@ function config_replicas() {
   "priority": 1
 }'
   # set all current indices to have 0 replicas
-  curl --cacert certs/root-ca.crt --user "elastic:$elastic_user_pass" -X PUT "https://127.0.0.1:9200/*/_settings" -H 'Content-Type: application/json' -d '{"index" : {"number_of_replicas" : 0}}'
+  curl --cacert certs/root-ca.crt --user "elastic:$elastic_user_pass" -X PUT "https://127.0.0.1:9200/_all/_settings" -H 'Content-Type: application/json' -d '{"index" : {"number_of_replicas" : 0}}'
 }
 
 function writeconfig() {

--- a/Chapter 3 Files/deploy.sh
+++ b/Chapter 3 Files/deploy.sh
@@ -658,9 +658,9 @@ function auto_os_updates() {
 }
 
 function config_replicas() {
-  echo -e "\n\e[32m[X]\e[0m Configuring elasticsearch Replica settings"
+  echo -e "\n\e[32m[X]\e[0m Configuring elasticsearch replica settings"
 
-  #set future index to always have no replicas
+  # set future index to always have no replicas
   curl --cacert certs/root-ca.crt --user "elastic:$elastic_user_pass" -X PUT "https://127.0.0.1:9200/_index_template/number_of_replicas" -H 'Content-Type: application/json' -d'{
   "index_patterns": ["*"],
   "template": {
@@ -670,7 +670,7 @@ function config_replicas() {
   },
   "priority": 1
 }'
-  #set all current indices to have 0 replicas
+  # set all current indices to have 0 replicas
   curl --cacert certs/root-ca.crt --user "elastic:$elastic_user_pass" -X PUT "https://127.0.0.1:9200/*/_settings" -H 'Content-Type: application/json' -d '{"index" : {"number_of_replicas" : 0}}'
 }
 


### PR DESCRIPTION
## 🗣 Description ##

Solves #124 

### 💭 Motivation and context 

the former function known as configelasticsearch used old commands from elasticsearch 6. 
the endpoint template no longer exists. See important statement at the top here: 
https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-templates-v1.html

Essentially the _template endpoint no longer exist. It has been replaced in elasticsearch 7.8 with _index_template. The previous commands means it was not successfully setting all future indexes to 1 replica. 

I also changed the function name as configelasticsearch seems to insinuate this one function configures all of elasticsearch - when in reality its only setting the replica number.

This sets the replica number to 0. This makes sense as we are deploying at this time only a single node instance -- so having multiple replicas would provide no redundancy and would only be taking up storage and cpu/memory resources. Ultimately, there are NO changes to what we were currently doing -- it was just old code before that wasn't working at all

Priority 1 just ensures this template has priority over any installed default templates that might be set to priority 0.

The code for setting CURRENT indexes to zero can remain the same as that code still works: 

https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-update-settings.html

From documentation:

`(Optional, string) Comma-separated list of data streams, indices, and aliases used to limit the request. Supports wildcards (*). To target all data streams and indices, omit this parameter or use * or _all.`

which applies to the next curl command in the script:

```
  curl --cacert certs/root-ca.crt --user "elastic:$elastic_user_pass" -X PUT "https://127.0.0.1:9200/_all/_settings" -H 'Content-Type: application/json' -d '{"index" : {"number_of_replicas" : 0}}'
}
```

## 🧪 Testing 

I did a full uninstall reinstall. 

Here's a screenshot of the install which no longer has the error we are getting with version 1.3.3:

![replica](https://github.com/cisagov/LME/assets/149685528/9ecebfa9-b52a-4220-97dc-661130d72296)

And here is a curl request AFTER install to show that it did actually set the templates to 0

![curloutput](https://github.com/cisagov/LME/assets/149685528/0c2df817-9421-4d2a-97a7-fda0fec9bfb0)


## ✅ Pre-approval checklist ##

- [x] Changes are limited to a single goal **AND** 
      the title reflects this in a clear human readable format
- [x] Issue that this PR solves has been selected in the Development section
- [x] I have read and agree to LME's [CONTRIBUTING.md](https://github.com/cisagov/LME/CONTRIBUTING.md) document.
- [x] The PR adheres to LME's requirements in [RELEASES.md](https://github.com/cisagov/LME/RELEASES.md#steps-to-submit-a-PR)
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.

## ✅ Pre-merge Checklist

- [x] All tests pass
- [x] PR has been tested and the documentation for testing is above
- [x] Squash and merge all commits into one PR level commit 

## ✅ Post-merge Checklist

- [ ] Delete the branch to keep down number of branches

