### PR TITLE
Append the flags to the end of the password file

### DIFF
--- a/.github/workflows/linux_only.yml
+++ b/.github/workflows/linux_only.yml
@@ -98,5 +98,5 @@ jobs:
       run: |
         cd testing/development
         docker compose -p ${{ env.UNIQUE_ID }} exec -T -u root lme bash -c "rm -rf /home/admin.ackbar/LME/.pytest_cache"
-        # docker compose -p ${{ env.UNIQUE_ID }} down
-        # docker system prune -a --force
+        docker compose -p ${{ env.UNIQUE_ID }} down
+        docker system prune -a --force

--- a/.github/workflows/linux_only.yml
+++ b/.github/workflows/linux_only.yml
@@ -62,16 +62,17 @@ jobs:
       run: docker compose -p ${{ env.UNIQUE_ID }} -f testing/development/docker-compose.yml build lme --no-cache
       
     - name: Run Docker Compose
-      run: docker compose -p ${{ env.UNIQUE_ID }} -f testing/development/docker-compose.yml up -d
+      run: docker compose -p ${{ env.UNIQUE_ID }} -f testing/development/docker-compose.yml up lme -d
       
     - name: List docker containers to wait for them to start
       run: |
         docker ps
-        
-    - name: Execute commands inside ubuntu container
-      run: |
-        cd testing/development
-        docker compose -p ${{ env.UNIQUE_ID }} exec -T ubuntu bash -c "echo 'Ubuntu container built'"
+    
+    # We are not using the ubuntu container so no use waiting for it to start
+    # - name: Execute commands inside ubuntu container
+    #   run: |
+    #     cd testing/development
+    #     docker compose -p ${{ env.UNIQUE_ID }} exec -T ubuntu bash -c "echo 'Ubuntu container built'"
         
     - name: Install LME in container
       run: |

--- a/.github/workflows/linux_only.yml
+++ b/.github/workflows/linux_only.yml
@@ -98,5 +98,5 @@ jobs:
       run: |
         cd testing/development
         docker compose -p ${{ env.UNIQUE_ID }} exec -T -u root lme bash -c "rm -rf /home/admin.ackbar/LME/.pytest_cache"
-        docker compose -p ${{ env.UNIQUE_ID }} down
-        docker system prune --force
+        # docker compose -p ${{ env.UNIQUE_ID }} down
+        # docker system prune -a --force

--- a/testing/InstallTestbed.ps1
+++ b/testing/InstallTestbed.ps1
@@ -384,3 +384,17 @@ $EsPasswords
 # Write the passwords to a file
 $PasswordPath = "..\..\${ResourceGroup}.password.txt"
 $EsPasswords | Out-File -Append -FilePath $PasswordPath
+
+# Constructing a string that will hold all the command-line parameters to be written to the file
+$paramsToWrite = @"
+ResourceGroup: $ResourceGroup
+DomainController: $DomainController
+LinuxVM: $LinuxVM
+NumClients: $NumClients
+LinuxOnly: $($LinuxOnly.IsPresent)
+Version: $Version
+Branch: $Branch
+"@
+
+# Output the parameters to the end of the password file
+$paramsToWrite | Out-File -Append -FilePath $PasswordPath

--- a/testing/InstallTestbed.ps1
+++ b/testing/InstallTestbed.ps1
@@ -398,3 +398,5 @@ Branch: $Branch
 
 # Output the parameters to the end of the password file
 $paramsToWrite | Out-File -Append -FilePath $PasswordPath
+
+Get-Content -Path $PasswordPath

--- a/testing/configure/lib/functions.sh
+++ b/testing/configure/lib/functions.sh
@@ -1,33 +1,25 @@
 extract_credentials() {
-    # Set default file path if not provided
     local file_path=${1:-'/opt/lme/Chapter 3 Files/output.log'}
-
-    # Check if the file exists
     if [ ! -f "$file_path" ]; then
         echo "File not found: $file_path"
         return 1
     fi
 
-    # Read and extract credentials from the last 18 lines
-    while IFS= read -r line; do
-        # Remove leading '## ' and trim whitespaces from the line
+    # Use a while loop directly reading from a process substitution
+    while IFS=: read -r line rest; do
         line=$(echo "$line" | sed 's/^## //g' | xargs)
+        rest=$(echo "$rest" | xargs)
 
-        # Split the line into key and value
-        key=$(echo "$line" | awk -F ':' '{print $1}')
-        value=$(echo "$line" | awk -F ':' '{print $2}' | xargs)  # xargs to trim whitespaces from value
-
-        # Remove non-word characters (keep only word characters)
-        value=$(echo "$value" | sed 's/[^[:alnum:]_]//g')
+        key=$(echo "$line" | awk '{print $1}')
+        value=$rest
 
         case $key in
-            "elastic") export elastic=$value ;;
-            "kibana") export kibana=$value ;;
-            "logstash_system") export logstash_system=$value ;;
-            "logstash_writer") export logstash_writer=$value ;;
-            "dashboard_update") export dashboard_update=$value ;;
+            "elastic" | "kibana" | "logstash_system" | "logstash_writer" | "dashboard_update")
+                export "$key"="$value"
+                ;;
         esac
-    done < <(tail -n 18 "$file_path" | grep -E "(elastic|kibana|logstash_system|logstash_writer|dashboard_update):")
+    done < <(awk '/^## \w+:/{print $0}' "$file_path")
+
     export ELASTIC_PASSWORD=$elastic
 }
 


### PR DESCRIPTION
## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->

### 💭 Motivation and context 
#193 
When doing multiple installs, it is hard to remember which flags were use to build clusters. 
Writing the flags to the password file will allow you to check what the flags were upon install. 

## 🧪 Testing 
Run InstallTestbed.ps1 and check that the flags were written to the file

## ✅ Pre-approval checklist ##

- [x] Changes are limited to a single goal **AND** 
      the title reflects this in a clear human readable format
- [x] Issue that this PR solves has been selected in the Development section
- [x] I have read and agree to LME's [CONTRIBUTING.md](https://github.com/cisagov/LME/CONTRIBUTING.md) document.
- [x] The PR adheres to LME's requirements in [RELEASES.md](https://github.com/cisagov/LME/RELEASES.md#steps-to-submit-a-PR)
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.

## ✅ Pre-merge Checklist

- [x] All tests pass
- [x] PR has been tested and the documentation for testing is above
- [x] Squash and merge all commits into one PR level commit 

## ✅ Post-merge Checklist

- [ ] Delete the branch to keep down number of branches

