### PR TITLE
Remove inline comments

### DIFF
--- a/quadlet/lme-fleet-server.container
+++ b/quadlet/lme-fleet-server.container
@@ -7,7 +7,7 @@ PartOf=lme.service
 
 [Service]
 Restart=always
-TimeoutStartSec=5400 #30 minutes, helps ensure does not fail due to health check
+TimeoutStartSec=5400
 Environment=ANSIBLE_VAULT_PASSWORD_FILE=/etc/lme/pass.sh
 
 [Install]

--- a/quadlet/lme-kibana.container
+++ b/quadlet/lme-kibana.container
@@ -10,7 +10,7 @@ WantedBy=default.target lme.service
 
 [Service]
 Restart=always
-TimeoutStartSec=5400 #30 minutes, helps ensure does not fail due to health check
+TimeoutStartSec=5400
 Environment=ANSIBLE_VAULT_PASSWORD_FILE=/etc/lme/pass.sh
 
 [Container]

--- a/quadlet/lme-wazuh-manager.container
+++ b/quadlet/lme-wazuh-manager.container
@@ -9,7 +9,7 @@ PartOf=lme.service
 Restart=always
 LimitNOFILE=655360
 Environment=ANSIBLE_VAULT_PASSWORD_FILE=/etc/lme/pass.sh
-TimeoutStartSec=5400 #30 minutes, helps ensure does not fail due to health check
+TimeoutStartSec=5400
 
 [Install]
 WantedBy=default.target lme.service


### PR DESCRIPTION
## 🗣 Description ##

Closes #531 

Removing inline comments from quadlets which cause parsing issues.

### 💭 Motivation and context 

Inline comments cause parsing issues. This causes pods to reset during install as the "timeout" section is not being sec properly. Comments will be removed so install goes without hiccups.

## 🧪 Testing 

Removed comments and tested an install.

## ✅ Pre-approval checklist ##

- [ ] Changes are limited to a single goal **AND** 
      the title reflects this in a clear human readable format
- [ ] Issue that this PR solves has been selected in the Development section
- [ ] I have read and agree to LME's [CONTRIBUTING.md](https://github.com/cisagov/LME/CONTRIBUTING.md) document.
- [ ] The PR adheres to LME's requirements in [RELEASES.md](https://github.com/cisagov/LME/RELEASES.md#steps-to-submit-a-PR)
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.

## ✅ Pre-merge Checklist

- [ ] All tests pass
- [ ] PR has been tested and the documentation for testing is above
- [ ] Squash and merge all commits into one PR level commit 

## ✅ Post-merge Checklist

- [ ] Delete the branch to keep down number of branches

