### PR TITLE
disable malware protection by default

### DIFF
--- a/ansible/post_install_local.yml
+++ b/ansible/post_install_local.yml
@@ -533,27 +533,7 @@
                   value:
                     type: "endpoint"
                     endpointConfig:
-                      preset: "EDRComplete"
-                policy:
-                  value:
-                    windows:
-                      malware:
-                        mode: "off"
-                        blocklist: false
-                        on_write_scan: false
-                      antivirus_registration:
-                        mode: "sync_with_malware_prevent"
-                        enabled: false
-                    mac:
-                      malware:
-                        mode: "off"
-                        blocklist: false
-                        on_write_scan: false
-                    linux:
-                      malware:
-                        mode: "off"
-                        blocklist: false
-                        on_write_scan: false
+                      preset: "DataCollection"
           package:
             name: "endpoint"
             title: "Elastic Defend"

--- a/ansible/post_install_local.yml
+++ b/ansible/post_install_local.yml
@@ -527,7 +527,7 @@
           inputs:
             - enabled: true
               streams: []
-              type: "endpoint"
+              type: "ENDPOINT_INTEGRATION_CONFIG"
               config:
                 _config:
                   value:

--- a/ansible/post_install_local.yml
+++ b/ansible/post_install_local.yml
@@ -527,13 +527,33 @@
           inputs:
             - enabled: true
               streams: []
-              type: "ENDPOINT_INTEGRATION_CONFIG"
+              type: "endpoint"
               config:
                 _config:
                   value:
                     type: "endpoint"
                     endpointConfig:
                       preset: "EDRComplete"
+                policy:
+                  value:
+                    windows:
+                      malware:
+                        mode: "off"
+                        blocklist: false
+                        on_write_scan: false
+                      antivirus_registration:
+                        mode: "sync_with_malware_prevent"
+                        enabled: false
+                    mac:
+                      malware:
+                        mode: "off"
+                        blocklist: false
+                        on_write_scan: false
+                    linux:
+                      malware:
+                        mode: "off"
+                        blocklist: false
+                        on_write_scan: false
           package:
             name: "endpoint"
             title: "Elastic Defend"

--- a/docs/markdown/agents/elastic-agent-management.md
+++ b/docs/markdown/agents/elastic-agent-management.md
@@ -81,6 +81,7 @@ This guide will walk you through the process of adding a Windows integration to 
    - Important note: If you have Sysmon installed on your endpoints, ensure "Sysmon Operational" is selected to collect Sysmon logs
 
 7. **Configure Metrics Collection**
+**NOTE: BE CAREFUL WITH METRICS. RECOMMENDATION IS TO ONLY USE ON SERVERS OR OTHER IMPORTANT ENDPOINTS NEEDING LIVE METRICS**
    - You can choose to collect various metrics from your Windows endpoints
    - Review and enable the metrics you're interested in monitoring
 

--- a/docs/markdown/agents/elastic-agent-management.md
+++ b/docs/markdown/agents/elastic-agent-management.md
@@ -81,7 +81,7 @@ This guide will walk you through the process of adding a Windows integration to 
    - Important note: If you have Sysmon installed on your endpoints, ensure "Sysmon Operational" is selected to collect Sysmon logs
 
 7. **Configure Metrics Collection**
-**NOTE: BE CAREFUL WITH METRICS. RECOMMENDATION IS TO ONLY USE ON SERVERS OR OTHER IMPORTANT ENDPOINTS NEEDING LIVE METRICS**
+**NOTE: BE CAREFUL WITH METRICS. RECOMMENDATION IS TO ONLY USE ON SERVERS OR OTHER IMPORTANT ENDPOINTS NEEDING LIVE METRICS. YOU MUST MANUALLY CLICK TO DISABLE.**
    - You can choose to collect various metrics from your Windows endpoints
    - Review and enable the metrics you're interested in monitoring
 


### PR DESCRIPTION
## 🗣 Description ##

#626 

This disables malware protection by default from Elastic Defend. Users can then decide to turn on malware protections as needed.

This also added a quick comment to documentation on Windows integration to only use Metrics if absolutely required. This requires manual intervention... user MUST click to disable.

### 💭 Motivation and context 

Elastic Defend and conflict with Windows Defender. This should be off by default since Defender is pretty common on all Windows Endpoints. Users can decide to use if wanted. 

### 📷 Screenshots (DELETE IF UNAPPLICABLE)

## 🧪 Testing 

Performed install, and in fleet verified that Malware protections were turned off by default. 

Must verify that defender doesn't get disabled on a Windows machine

## ✅ Pre-approval checklist ##

- [x] Changes are limited to a single goal **AND** 
      the title reflects this in a clear human readable format
- [x] Issue that this PR solves has been selected in the Development section
- [ ] I have read and agree to LME's [CONTRIBUTING.md](https://github.com/cisagov/LME/CONTRIBUTING.md) document.
- [x] The PR adheres to LME's requirements in [RELEASES.md](https://github.com/cisagov/LME/RELEASES.md#steps-to-submit-a-PR)
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.

## ✅ Pre-merge Checklist

- [ ] All tests pass
- [ ] PR has been tested and the documentation for testing is above
- [ ] Squash and merge all commits into one PR level commit 

## ✅ Post-merge Checklist

- [ ] Delete the branch to keep down number of branches

