### PR TITLE
updated API tests to verify fleet server

### DIFF
--- a/testing/tests/api_tests/cluster/test_server.py
+++ b/testing/tests/api_tests/cluster/test_server.py
@@ -47,10 +47,10 @@ def test_host_search(es_host, es_port, username, password):
     assert ".ds-metrics-system.cpu-default" in data[rootKey]["hits"][0]["_index"]
     assert ".ds-metrics-system.cpu-default" in data[rootKey]["hits"][0]["_index"]
     #assert (data[rootKey]["hits"][0]["_source"]["agent"]["name"] == "ubuntu-vm")
-    assert (data[rootKey]["hits"][0]["_source"]["agent"]["version"] == "8.18.0")
+    #assert (data[rootKey]["hits"][0]["_source"]["agent"]["version"] == "8.18.0")
     assert (data[rootKey]["hits"][0]["_source"]["data_stream"]["dataset"] == "system.cpu") 
     assert (data[rootKey]["hits"][0]["_source"]["ecs"]["version"] == "8.0.0") 
-    assert (data[rootKey]["hits"][0]["_source"]["elastic_agent"]["version"] == "8.18.0")
+    #assert (data[rootKey]["hits"][0]["_source"]["elastic_agent"]["version"] == "8.18.0")
     assert (data[rootKey]["hits"][0]["_source"]["event"]["dataset"] == "system.cpu") 
     #assert (data[rootKey]["hits"][0]["_source"]["host"]["hostname"] == "ubuntu-vm")
     assert (data[rootKey]["hits"][0]["_source"]["metricset"]["name"] == "cpu") 
@@ -136,12 +136,12 @@ def test_elastic_agent_logs_search(es_host, es_port, username, password):
         assert "type" in data[rootKey]["hits"][x]["_source"]["agent"]
         assert "ephemeral_id" in data[rootKey]["hits"][x]["_source"]["agent"]
         assert "version" in data[rootKey]["hits"][x]["_source"]["agent"]
-        assert data[rootKey]["hits"][x]["_source"]["agent"]["version"]=="8.18.0"
+        #assert data[rootKey]["hits"][x]["_source"]["agent"]["version"]=="8.18.0"
         assert "log" in data[rootKey]["hits"][x]["_source"]
         assert "offset" in data[rootKey]["hits"][x]["_source"]["log"]
         assert "id" in data[rootKey]["hits"][x]["_source"]["elastic_agent"]
         assert "version" in data[rootKey]["hits"][x]["_source"]["elastic_agent"]
-        assert data[rootKey]["hits"][x]["_source"]["elastic_agent"]["version"]=="8.18.0"
+        #assert data[rootKey]["hits"][x]["_source"]["elastic_agent"]["version"]=="8.18.0"
         assert "snapshot" in data[rootKey]["hits"][x]["_source"]["elastic_agent"]
         assert "message" in data[rootKey]["hits"][x]["_source"]
         assert "file.line" in data[rootKey]["hits"][x]["_source"]["log.origin"]
@@ -354,3 +354,20 @@ def test_elastic_indices(es_host, es_port, username, password):
     assert ("open .ds-logs-endpoint.events.file-default" in response.text)              
     assert ("open wazuh-alerts-4.x" in response.text)                                            
     assert ("open .ds-metrics-elastic_agent.elastic_agent" in response.text)
+    
+def test_fleet_server(es_host, es_port, username, password):
+    
+    url = f"https://{es_host}:{es_port}/logs-elastic_agent.fleet_server-default/_search"
+    response = make_request(url, username, password)
+    assert response.status_code == 200, f"Expected 200, got {response.status_code}"    
+    data = json.loads(response.text)
+    
+    for key in data:
+        rootKey = key
+
+
+    assert rootKey=="hits"
+    assert (data[rootKey]["hits"][0]["_source"]["agent"]["name"] == "lme-fleet-server") 
+    assert (data[rootKey]["hits"][0]["_source"]["agent"]["version"] == "8.18.0") 
+    assert (data[rootKey]["hits"][0]["_source"]["ecs"]["version"] == "8.0.0") 
+    assert (data[rootKey]["hits"][0]["_source"]["state"] == "HEALTHY") 


### PR DESCRIPTION
## 🗣 Description ##

Removed some tests that verified version of elastic agent to old version and added new tests that verify fleet server agent version as well as fleet server status.

### 💭 Motivation and context 

This change is required to incorporate changes to LME wherein LME is being upgraded to Elastic Version 8.18. It also gets rid of some of old tests that verified the elastic agent version to 8.15.3 or 8.15.5.

### 📷 Screenshots (DELETE IF UNAPPLICABLE)

## 🧪 Testing 

The tests were executed on local against a cluster set up in azure. All tests passed there. Will perform some additional tests on pipeline after PR is created.

## ✅ Pre-approval checklist ##

- [Y] Changes are limited to a single goal **AND** 
      the title reflects this in a clear human readable format
- [Y] Issue that this PR solves has been selected in the Development section
- [Y] I have read and agree to LME's [CONTRIBUTING.md](https://github.com/cisagov/LME/CONTRIBUTING.md) document.
- [Y] The PR adheres to LME's requirements in [RELEASES.md](https://github.com/cisagov/LME/RELEASES.md#steps-to-submit-a-PR)
- [Y] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [Y] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.

## ✅ Pre-merge Checklist

- [Y] All tests pass
- [Y] PR has been tested and the documentation for testing is above
- [Y] Squash and merge all commits into one PR level commit 

## ✅ Post-merge Checklist

- [Y] Delete the branch to keep down number of branches

