### PR TITLE
Adds a fix to not install nix from apt

### DIFF
--- a/ansible/roles/nix/tasks/main.yml
+++ b/ansible/roles/nix/tasks/main.yml
@@ -3,14 +3,16 @@
 - name: Include OS-specific variables
   include_vars: "{{ item }}"
   with_first_found:
-    - "{{ ansible_distribution | lower }}.yml"
-    - "{{ ansible_os_family | lower }}.yml"
-    - "default.yml"
+    - "vars/{{ ansible_distribution | lower }}-{{ ansible_distribution_version }}.yml"
+    - "vars/{{ ansible_distribution | lower }}.yml"
+    - "vars/{{ ansible_os_family | lower }}.yml"
+    - "vars/default.yml"
 
 # Include OS-specific tasks
 - name: Include OS-specific tasks
   include_tasks: "{{ item }}"
   with_first_found:
+    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_version }}.yml"
     - "{{ ansible_distribution | lower }}.yml"
     - "{{ ansible_os_family | lower }}.yml"
     - "common.yml"

--- a/ansible/roles/nix/tasks/ubuntu-22.04.yml
+++ b/ansible/roles/nix/tasks/ubuntu-22.04.yml
@@ -1,0 +1,78 @@
+---
+# Ubuntu 22.04: Install Nix via official installer (apt version is too old)
+
+- name: Check if Nix is already installed
+  stat:
+    path: /nix/var/nix/profiles/default/bin/nix
+  register: nix_installed
+
+- name: Create nix installation directory
+  file:
+    path: /opt/nix-install
+    state: directory
+    mode: '0755'
+  become: yes
+  when: not nix_installed.stat.exists
+
+- name: Create temporary directory for Nix install
+  file:
+    path: /opt/nix-install/tmp
+    state: directory
+    mode: '0755'
+  become: yes
+  when: not nix_installed.stat.exists
+
+- name: Download Nix installer
+  get_url:
+    url: https://nixos.org/nix/install
+    dest: /opt/nix-install/install-nix.sh
+    mode: '0755'
+  become: yes
+  when: not nix_installed.stat.exists
+
+- name: Install Nix package manager
+  shell: sh /opt/nix-install/install-nix.sh --daemon --yes
+  become: yes
+  environment:
+    TMPDIR: /opt/nix-install/tmp
+  when: not nix_installed.stat.exists
+
+- name: Ensure nix-daemon service is started
+  systemd:
+    name: nix-daemon
+    state: started
+    enabled: yes
+  become: yes
+
+- name: Ensure nix-users group exists
+  group:
+    name: nix-users
+    state: present
+  become: yes
+
+- name: Add user to nix-users group
+  user:
+    name: "{{ install_user }}"
+    groups: nix-users
+    append: yes
+  become: yes
+
+- name: Add Nix channel
+  command: nix-channel --add https://nixos.org/channels/nixpkgs-unstable nixpkgs
+  become: yes
+  environment:
+    PATH: "{{ ansible_env.PATH }}:/nix/var/nix/profiles/default/bin"
+
+- name: Update Nix channel
+  command: nix-channel --update
+  become: yes
+  environment:
+    PATH: "{{ ansible_env.PATH }}:/nix/var/nix/profiles/default/bin"
+
+- name: Install required packages
+  command: nix-env -iA nixpkgs.podman nixpkgs.docker-compose
+  become: yes 
+  environment:
+    PATH: "{{ ansible_env.PATH }}:/nix/var/nix/profiles/default/bin"
+
+

--- a/ansible/roles/nix/tasks/ubuntu.yml
+++ b/ansible/roles/nix/tasks/ubuntu.yml
@@ -1,5 +1,5 @@
 ---
-# Ubuntu-specific Nix setup
+# Ubuntu-specific Nix setup (non-22.04: apt-based)
 
 - name: Update apt cache
   apt:


### PR DESCRIPTION
## 🗣 Description ##
Install nix from nix instead of apt

### 💭 Motivation and context 
The apt version of nix was too old to use the unstable channel


## 🧪 Testing 
Install lme on a ubuntu 22.04 machine and test as usual. 

## ✅ Pre-approval checklist ##

- [ ] Changes are limited to a single goal **AND** 
      the title reflects this in a clear human readable format
- [ ] Issue that this PR solves has been selected in the Development section
- [ ] I have read and agree to LME's [CONTRIBUTING.md](https://github.com/cisagov/LME/CONTRIBUTING.md) document.
- [ ] The PR adheres to LME's requirements in [RELEASES.md](https://github.com/cisagov/LME/RELEASES.md#steps-to-submit-a-PR)
- [ ] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.

## ✅ Pre-merge Checklist

- [ ] All tests pass
- [ ] PR has been tested and the documentation for testing is above
- [ ] Squash and merge all commits into one PR level commit 

## ✅ Post-merge Checklist

- [ ] Delete the branch to keep down number of branches

