### PR TITLE
feat(setup.sh): adding graphroot flag

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ usage() {
     echo "  -o, --offline                 Enable offline mode (skip internet-dependent tasks)"
     echo "  --skip-packages               Skip package installation (for development)"
     echo "  -p, --playbook PLAYBOOK_PATH  Specify path to playbook (default: ./ansible/site.yml)"
-    echo "  -g, --graph-root              Change the graphroot directory (where volumes are stored)"
+    echo "  -g, --graph-root GRAPH_ROOT   Change the graphroot directory (where volumes are stored)"
     echo "  -h, --help                    Show this help message"
     echo
     echo "Environment Variables:"

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,7 @@ IPVAR=""
 DEBUG_MODE="false"
 OFFLINE_MODE="false"
 SKIP_PACKAGES="false"
+GRAPH_ROOT="/var/lib/containers/storage"
 
 # Environment variables for non-interactive mode
 NON_INTERACTIVE=${NON_INTERACTIVE:-false}
@@ -31,6 +32,7 @@ usage() {
     echo "  -o, --offline                 Enable offline mode (skip internet-dependent tasks)"
     echo "  --skip-packages               Skip package installation (for development)"
     echo "  -p, --playbook PLAYBOOK_PATH  Specify path to playbook (default: ./ansible/site.yml)"
+    echo "  -g, --graph-root              Change the graphroot directory (where volumes are stored)"
     echo "  -h, --help                    Show this help message"
     echo
     echo "Environment Variables:"
@@ -64,6 +66,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         -p|--playbook)
             PLAYBOOK_PATH="$2"
+            shift 2
+            ;;
+        -g|--graph-root)
+            GRAPH_ROOT="$2"
             shift 2
             ;;
         -h|--help)
@@ -494,9 +500,9 @@ run_playbook() {
     sudo chown $(whoami):$(whoami) /opt/ansible-tmp
 
     if [ -f "$SCRIPT_DIR/inventory" ]; then
-        ansible-playbook -i "$SCRIPT_DIR/inventory" "$PLAYBOOK_PATH" --extra-vars '{"has_sudo_access":"'"${HAS_SUDO_ACCESS}"'","clone_dir":"'"${SCRIPT_DIR}"'","offline_mode":'"${OFFLINE_MODE}"'}' $ANSIBLE_OPTS
+        ansible-playbook -i "$SCRIPT_DIR/inventory" "$PLAYBOOK_PATH" --extra-vars '{"has_sudo_access":"'"${HAS_SUDO_ACCESS}"'","clone_dir":"'"${SCRIPT_DIR}"'","offline_mode":'"${OFFLINE_MODE}"', "storage_graphroot": '"${GRAPH_ROOT}"'}' $ANSIBLE_OPTS
     else
-        ansible-playbook "$PLAYBOOK_PATH" --extra-vars '{"has_sudo_access":"'"${HAS_SUDO_ACCESS}"'","clone_dir":"'"${SCRIPT_DIR}"'","offline_mode":'"${OFFLINE_MODE}"'}' $ANSIBLE_OPTS
+        ansible-playbook "$PLAYBOOK_PATH" --extra-vars '{"has_sudo_access":"'"${HAS_SUDO_ACCESS}"'","clone_dir":"'"${SCRIPT_DIR}"'","offline_mode":'"${OFFLINE_MODE}"', "storage_graphroot": '"${GRAPH_ROOT}"'}' $ANSIBLE_OPTS
     fi
     
     if [ $? -eq 0 ]; then


### PR DESCRIPTION
## 🗣 Description ##

Adding a -g flag to change the graphroot of the podman install. This functionality is already provided in the ansible playbooks; this PR just exposes it to the setup script. Minor changes to `setup.sh`

### 💭 Motivation and context 

This will be useful for users attempting to store their podman container data on another disk or NAS (anything but the drive the OS is installed on). The flag is optional. Any existing instructions / scripts will not have to be changed. 

This is a necessary change to allow people to install on different drive / NAS without having to run all the playbooks by hand.


## 🧪 Testing 
Tested in virtual environments. Running script as given in all documentation does not change any behavior. Providing the `-g` flag will install podman containers / volumes to the new directory.  

## ✅ Pre-approval checklist ##

- [x] Changes are limited to a single goal **AND** 
      the title reflects this in a clear human readable format
- [ ] Issue that this PR solves has been selected in the Development section
- [x] I have read and agree to LME's [CONTRIBUTING.md](https://github.com/cisagov/LME/CONTRIBUTING.md) document.
- [x] The PR adheres to LME's requirements in [RELEASES.md](https://github.com/cisagov/LME/RELEASES.md#steps-to-submit-a-PR)
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [ ] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
  - Documentation is written for installing to different drives / NAS. Documentation will go live after this change is merged in.

## ✅ Pre-merge Checklist

- [ ] All tests pass
- [ ] PR has been tested and the documentation for testing is above
- [ ] Squash and merge all commits into one PR level commit 

## ✅ Post-merge Checklist

- [ ] Delete the branch to keep down number of branches

